### PR TITLE
Limit scope of use cases to metadata

### DIFF
--- a/USE-CASES/README.md
+++ b/USE-CASES/README.md
@@ -1,5 +1,10 @@
 ## WoT Discovery General Topics and Use Cases
 
+### Scope
+* Limit to metadata discovery (as opposed to data discovery).
+** Search of historical data is useful
+   but is a separate problem with additional privacy implications and goes beyond our charter.
+
 ### Template
 
 Please select to which category your use case belongs and describe your use case with the help of this template:


### PR DESCRIPTION
Propose limiting scope of discovery to metadata (eg Thing Descriptions), not actual sensor data.
Discovery of sensor data is definitely useful but raises many issues and is not included in our current charter.