### PR TITLE
Draft of registration API

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -1,0 +1,186 @@
+{
+    "@context": "https://www.w3.org/2019/wot/td/v1",
+    "@type": "WoT-Directory", // namespace?
+    "title": "Thing Description Directory (TDD)",
+    "securityDefinitions": {
+        "oauth2_code": {
+            "scheme": "oauth2",
+            "flow": "code",
+            "authorization": "https://auth.example.com/authorization",
+            "token": "https://auth.example.com/token",
+            "scopes": [
+                "write",
+                "read",
+                "search"
+            ]
+        }
+    },
+    "security": "oauth2_code",
+    "base": "https://tdd.example.com",
+    "actions": {
+        "createTD": {
+            "description": "Add a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td/{id}", // use /registrations instead?
+                    "htv:methodName": "PUT",
+                    "contentType": "application/td+json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 201
+                    },
+                    "scopes": "write"
+                },
+                {
+                    "href": "/td",
+                    "htv:methodName": "POST",
+                    "contentType": "application/td+json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:headers": [
+                            {
+                                "description": "System-generated UUID (version 4) URN", // need to define vocab?
+                                "htv:fieldName": "Location",
+                                "htv:fieldValue": ""
+                            }
+                        ],
+                        "htv:statusCodeValue": 201
+                    },
+                    "scopes": "write"
+                }
+            ]
+        },
+        "updateTD": {
+            "description": "Modify an Thing Description",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td/{id}",
+                    "htv:methodName": "PUT",
+                    "contentType": "application/td+json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 204
+                    },
+                    "scopes": "write"
+                }
+            ]
+        },
+        "updatePartialTD": {
+            "description": "Modify parts of a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td/{id}",
+                    "htv:methodName": "PATCH",
+                    "contentType": "application/td+json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 204
+                    },
+                    "scopes": "write"
+                }
+            ]
+        },
+        "deleteTD": {
+            "description": "Remove a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td/{id}",
+                    "htv:methodName": "DELETE",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 204
+                    },
+                    "scopes": "write"
+                }
+            ]
+        }
+    },
+    "properties": {
+        "readTD": {
+            "description": "Retrieve a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td/{id}",
+                    "htv:methodName": "GET",
+                    "htv:statusCodeValue": 200,
+                    "contentType": "application/td+json",
+                    "scopes": "read"
+                }
+            ]
+        },
+        "listTD": {
+            "description": "List and filter Thing Descriptions",
+            "uriVariables": {
+                "per_page": {
+                    "title": "Number of TDs in response catalog page",
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100
+                },
+                "page": {
+                    "title": "Response catalog page",
+                    "type": "number",
+                    "minimum": 1
+                },
+                "oneOf": {
+                    "xpath": {
+                        "title": "XPath query expression",
+                        "type": "string"
+                    },
+                    "jsonpath": {
+                        "title": "JSONPath query expression",
+                        "type": "string"
+                    },
+                    "sparql": {
+                        "title": "SPARQL query",
+                        "type": "string"
+                    }
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td{?page,per_page,xpath,jsonpath,sparql}",
+                    "htv:methodName": "GET",
+                    "htv:statusCodeValue": 200,
+                    "contentType": "application/json",
+                    "scopes": "search"
+                }
+            ]
+        }
+    }
+}

--- a/directory.td.json
+++ b/directory.td.json
@@ -1,6 +1,6 @@
 {
     "@context": "https://www.w3.org/2019/wot/td/v1",
-    "@type": "WoT-Directory",
+    "@type": "Directory",
     "title": "Thing Description Directory (TDD)",
     "version": {
         "instance": "1.0.0-alpha"

--- a/directory.td.json
+++ b/directory.td.json
@@ -1,6 +1,6 @@
 {
     "@context": "https://www.w3.org/2019/wot/td/v1",
-    "@type": "WoT-Directory", // namespace?
+    "@type": "WoT-Directory",
     "title": "Thing Description Directory (TDD)",
     "version": {
         "instance": "1.0.0-alpha"
@@ -32,11 +32,11 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}", // use /registrations instead?
+                    "href": "/td/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:statusCodeValue": 201
                     },
                     "scopes": "write"
@@ -46,10 +46,10 @@
                     "htv:methodName": "POST",
                     "contentType": "application/td+json",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:headers": [
                             {
-                                "description": "System-generated UUID (version 4) URN", // need to define vocab?
+                                "description": "System-generated UUID (version 4) URN",
                                 "htv:fieldName": "Location",
                                 "htv:fieldValue": ""
                             }
@@ -75,7 +75,7 @@
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:statusCodeValue": 204
                     },
                     "scopes": "write"
@@ -97,7 +97,7 @@
                     "htv:methodName": "PATCH",
                     "contentType": "application/td+json",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:statusCodeValue": 204
                     },
                     "scopes": "write"
@@ -118,7 +118,7 @@
                     "href": "/td/{id}",
                     "htv:methodName": "DELETE",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:statusCodeValue": 204
                     },
                     "scopes": "write"
@@ -141,53 +141,11 @@
                     "href": "/td/{id}",
                     "htv:methodName": "GET",
                     "response": {
-                        "description": "Success response", // need to define vocab?
+                        "description": "Success response",
                         "htv:statusCodeValue": 200,
                         "contentType": "application/td+json"
                     },
                     "scopes": "read"
-                }
-            ]
-        },
-        "listTDs": {
-            "description": "List and filter Thing Descriptions, paginated as a catalog",
-            "uriVariables": {
-                "per_page": {
-                    "title": "Number of TDs in each catalog page",
-                    "type": "number",
-                    "minimum": 1,
-                    "maximum": 100
-                },
-                "page": {
-                    "title": "Page number of the catalog",
-                    "type": "number",
-                    "minimum": 1
-                },
-                "oneOf": {
-                    "xpath": {
-                        "title": "XPath query expression",
-                        "type": "string"
-                    },
-                    "jsonpath": {
-                        "title": "JSONPath query expression",
-                        "type": "string"
-                    },
-                    "sparql": { // can sparql results be paginated with query params?
-                        "title": "SPARQL query",
-                        "type": "string"
-                    }
-                }
-            },
-            "forms": [
-                {
-                    "href": "/td{?page,per_page,xpath,jsonpath,sparql}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response", // need to define vocab?
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/json"
-                    },
-                    "scopes": "search"
                 }
             ]
         }

--- a/directory.td.json
+++ b/directory.td.json
@@ -2,6 +2,9 @@
     "@context": "https://www.w3.org/2019/wot/td/v1",
     "@type": "WoT-Directory", // namespace?
     "title": "Thing Description Directory (TDD)",
+    "version": {
+        "instance": "1.0.0-alpha"
+    },
     "securityDefinitions": {
         "oauth2_code": {
             "scheme": "oauth2",
@@ -19,7 +22,7 @@
     "base": "https://tdd.example.com",
     "actions": {
         "createTD": {
-            "description": "Add a Thing Description",
+            "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
                     "title": "Thing Description ID",
@@ -58,7 +61,7 @@
             ]
         },
         "updateTD": {
-            "description": "Modify an Thing Description",
+            "description": "Update an Thing Description",
             "uriVariables": {
                 "id": {
                     "title": "Thing Description ID",
@@ -80,7 +83,7 @@
             ]
         },
         "updatePartialTD": {
-            "description": "Modify parts of a Thing Description",
+            "description": "Update parts of a Thing Description",
             "uriVariables": {
                 "id": {
                     "title": "Thing Description ID",
@@ -102,7 +105,7 @@
             ]
         },
         "deleteTD": {
-            "description": "Remove a Thing Description",
+            "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {
                     "title": "Thing Description ID",
@@ -124,7 +127,7 @@
         }
     },
     "properties": {
-        "readTD": {
+        "retrieveTD": {
             "description": "Retrieve a Thing Description",
             "uriVariables": {
                 "id": {
@@ -137,23 +140,26 @@
                 {
                     "href": "/td/{id}",
                     "htv:methodName": "GET",
-                    "htv:statusCodeValue": 200,
-                    "contentType": "application/td+json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
                     "scopes": "read"
                 }
             ]
         },
-        "listTD": {
-            "description": "List and filter Thing Descriptions",
+        "listTDs": {
+            "description": "List and filter Thing Descriptions, paginated as a catalog",
             "uriVariables": {
                 "per_page": {
-                    "title": "Number of TDs in response catalog page",
+                    "title": "Number of TDs in each catalog page",
                     "type": "number",
                     "minimum": 1,
                     "maximum": 100
                 },
                 "page": {
-                    "title": "Response catalog page",
+                    "title": "Page number of the catalog",
                     "type": "number",
                     "minimum": 1
                 },
@@ -166,7 +172,7 @@
                         "title": "JSONPath query expression",
                         "type": "string"
                     },
-                    "sparql": {
+                    "sparql": { // can sparql results be paginated with query params?
                         "title": "SPARQL query",
                         "type": "string"
                     }
@@ -176,8 +182,11 @@
                 {
                     "href": "/td{?page,per_page,xpath,jsonpath,sparql}",
                     "htv:methodName": "GET",
-                    "htv:statusCodeValue": 200,
-                    "contentType": "application/json",
+                    "response": {
+                        "description": "Success response", // need to define vocab?
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/json"
+                    },
                     "scopes": "search"
                 }
             ]

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@ img.wot-diagram {
                If the URL references a Directory, this MUST be the TD of the
                Directory service.
                A Directory can be distinguished from a Thing by the use of an
-               <code>@type</code> including the semantic term <code>WoT-Directory</code>.
+               <code>@type</code> including the semantic term <code>Directory</code>.
             </p>
         </section>
         <section id="introduction-dns-sd" class="normative">

--- a/index.html
+++ b/index.html
@@ -95,6 +95,9 @@ img.wot-diagram {
     max-width: 90%;
     height: auto;
 }
+.rfc2119-assertion {
+  background-color: rgb(230,230,230)
+}
 </style>
 </head>
 <body>
@@ -278,11 +281,9 @@ img.wot-diagram {
             </section>
             <section id="exploration-directory-api" class="normative">
                 <h3>Directory Service API</h3>
-                <span class="rfc2119-assertion" id="tdd-secure-protocols"> 
-                    The Directory APIs MUST use secure protocols guaranteeing 
-                    <a href="https://www.w3.org/TR/wot-security/#dfn-system-user-data">System User Data</a> 
-                    authenticity and confidentiality (see [[?WOT-SECURITY-GUIDELINES]]).
-                </span>
+                The Directory APIs must use secure protocols guaranteeing 
+                <a href="https://www.w3.org/TR/wot-security/#dfn-system-user-data">System User Data</a> 
+                authenticity and confidentiality (see [[?WOT-SECURITY-GUIDELINES]]).
                 <span class="rfc2119-assertion" id="tdd-https"> 
                     All HTTP APIs MUST be exposed over HTTPS (HTTP Over TLS).
                 </span>
@@ -331,34 +332,56 @@ img.wot-diagram {
 
                     <dl><dt>Create a TD:</dt><dd>
                         <p>
-                            The API MUST allow registration of a TD object passed as request body. The request
-                            SHOULD contain `application/td+json` Content-Type header for JSON serialization of TD.
-                            The TD object SHOULD be validated syntactically using the 
-                            <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
-                            [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                            <span class="rfc2119-assertion" id="tdd-reg-create-body">
+                                The API MUST allow registration of a TD object passed as request body.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-reg-create-contenttype">
+                                The request SHOULD contain `application/td+json` Content-Type header for 
+                                JSON serialization of TD.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-reg-create-validation">
+                                The TD object SHOULD be validated syntactically using the 
+                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                            </span>
                         </p>
                         <p>
-                            A TD which is identified with an `id` attribute MUST be handled 
-                            differently with one that has no identifier (<a>Anonymous TD</a>). The create operations
-                            are specified as `createTD` action in 
+                            <span class="rfc2119-assertion" id="tdd-reg-types"> 
+                                A TD which is identified with an `id` attribute MUST be handled 
+                                differently with one that has no identifier (<a>Anonymous TD</a>).
+                            </span>
+                            The create operations are specified as `createTD` action in 
                             <a href="#directory-thing-description">Directory's Thing Description</a>
                             and elaborated below:
                         </p>
                         <ul>
                             <li>
-                                A TD MUST be submitted to the directory using an HTTP `PUT` request at a  
-                                target location (HTTP path) containing the unique TD `id`. 
-                                Upon successful processing, the server MUST respond with
-                                201 (Created) status.                             
-                                <br>Note: If the target location corresponds to an existing TD,
-                                the request shall instead proceed as an Update operation and respond
-                                the appropriate status code (see Update section).
+                                <span class="rfc2119-assertion" id="tdd-reg-create-known-td">
+                                    A TD MUST be submitted to the directory using an HTTP `PUT` request at a  
+                                    target location (HTTP path) containing the unique TD `id`.
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-create-known-td-resp">  
+                                    Upon successful processing, the server MUST respond with
+                                    201 (Created) status.                           
+                                </span>
+
+                                <p>
+                                    Note: If the target location corresponds to an existing TD,
+                                    the request shall instead proceed as an Update operation and respond
+                                    the appropriate status code (see Update section).
+                                </p>
                             </li>
                             <li>
-                                An <a>Anonymous TD</a> MUST be submitted to the directory using an HTTP `POST` request. 
-                                Upon successful processing, the server MUST respond with 201 (Created) status
-                                and a Location header containing a system-generated identifier for the TD.
-                                The identifier SHOULD be a Version 4 UUID URN [[RFC4122]].
+                                <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td">
+                                    An <a>Anonymous TD</a> MUST be submitted to the directory using an HTTP `POST` request. 
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td-resp">
+                                    Upon successful processing, the server MUST respond with 201 (Created) status
+                                    and a Location header containing a system-generated identifier for the TD.
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td-generated-id"></span>
+                                    The identifier SHOULD be a Version 4 UUID URN [[RFC4122]].
+                                </span>
                             </li>
                         </ul>
 
@@ -387,11 +410,15 @@ img.wot-diagram {
                     
                     <dl><dt>Retrieve a TD:</dt><dd>
                         <p>
-                            A TD MUST be retrieved from the directory using an HTTP `GET` request. The request
-                            MUST include the identifier of the TD as part of the path. A successful response
-                            MUST have 200 (OK) status, contain `application/td+json` Content-Type header,
-                            and the requested TD in body. The retrieve operation is specified as `retrieveTD` 
-                            property in 
+                            <span class="rfc2119-assertion" id="tdd-reg-retrieve">
+                                A TD MUST be retrieved from the directory using an HTTP `GET` request,
+                                including the identifier of the TD as part of the path.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-reg-retrieve-resp">
+                                A successful response MUST have 200 (OK) status, contain `application/td+json`
+                                Content-Type header, and the requested TD in body.
+                            </span>
+                            The retrieve operation is specified as `retrieveTD` property in 
                             <a href="#directory-thing-description">Directory's Thing Description</a>.
                         </p>
 
@@ -413,35 +440,63 @@ img.wot-diagram {
                     
                     <dl><dt>Update a TD:</dt><dd>
                         <p>
-                            The API MUST allow modifications to existing TDs as full replacement or partial updates.
-                            The request SHOULD contain `application/td+json` Content-Type header for JSON serialization
-                            of TD. The update operations are described below:
+                            <span class="rfc2119-assertion" id="tdd-reg-update-types">
+                                The API MUST allow modifications to existing TDs as full replacement or partial updates.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-reg-update-contenttype">
+                                The request SHOULD contain `application/td+json` Content-Type header for JSON
+                                serialization of TD.
+                            </span>
+                            The update operations are described below:
                         </p>
 
                         <ul>
                             <li>
-                                A modified TD MUST replace an existing when submitted using an HTTP `PUT` request
-                                to the location corresponding to the existing TD. The TD object SHOULD be
-                                validated syntactically using the 
-                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
-                                [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
-                                Upon success, the server MUST respond with 204 (No Content) status. 
+                                <span class="rfc2119-assertion" id="tdd-reg-update">
+                                    A modified TD MUST replace an existing one when submitted using an HTTP `PUT` request
+                                    to the location corresponding to the existing TD.
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-update-validation">
+                                    The TD object SHOULD be
+                                    validated syntactically using the 
+                                    <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                    [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-update-resp">
+                                    Upon success, the server MUST respond with 204 (No Content) status. 
+                                </span>
                                 This operation is specified as `updateTD` property in 
                                 <a href="#directory-thing-description">Directory's Thing Description</a>.
-                                <br>Note: If the target location does not correspond to an existing TD,
-                                the request shall instead proceed as a Create operation and respond
-                                the appropriate status code (see Create section). In other words, an HTTP `PUT`
-                                request acts as a create or update operation. An HTTP `PATCH` may be used for
-                                an update-only operation.
+
+                                <p>
+                                    Note: If the target location does not correspond to an existing TD,
+                                    the request shall instead proceed as a Create operation and respond
+                                    the appropriate status code (see Create section). In other words, an HTTP `PUT`
+                                    request acts as a create or update operation. An HTTP `PATCH` may be used for
+                                    an update-only operation.
+                                </p>
                             </li>
                             <li>
-                                An existing TD MUST be partially modified when the modified parts are submitted using an 
-                                HTTP `PATCH` request. The modified parts MUST conform to the original TD structure 
-                                and may include other existing parts of the TD. After applying the modifications,
-                                the TD object SHOULD be validated syntactically using the 
-                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
-                                [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
-                                Upon success, the server MUST respond with a 204 (No Content) status.
+                                <span class="rfc2119-assertion" id="tdd-reg-update-partial">
+                                    An existing TD MUST be partially modified when the modified parts are submitted using an 
+                                    HTTP `PATCH` request to the location corresponding to the existing TD.
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-update-partial-partialtd">
+                                    The modified parts MUST conform to the original TD structure. 
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-update-partial-fulltd">
+                                    The input MAY include other existing parts of the TD or the whole TD object.
+                                </span>
+                                When the whole TD object is provided as input, the operation acts as an update-only action.
+                                <span class="rfc2119-assertion" id="tdd-reg-update-partial-validation">
+                                    After applying the modifications,
+                                    the TD object SHOULD be validated syntactically using the 
+                                    <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                    [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                                </span>
+                                <span class="rfc2119-assertion" id="tdd-reg-update-partial-resp">
+                                    Upon success, the server MUST respond with a 204 (No Content) status.
+                                </span>
                                 This operation is specified as `updatePartialTD` property in 
                                 <a href="#directory-thing-description">Directory's Thing Description</a>.
                             </li>
@@ -469,9 +524,13 @@ img.wot-diagram {
                     
                     <dl><dt>Delete a TD:</dt><dd>
                         <p>
-                            A TD must be removed from the directory using an HTTP `DELETE` request.
-                            The request should include the identifier of the TD as part of the path. 
-                            A successful response MUST have 204 (No Content) status.
+                            <span class="rfc2119-assertion" id="tdd-reg-update-delete">
+                                A TD MUST be removed from the directory when an HTTP `DELETE` request
+                                is submitted to the location corresponding to the existing TD.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-reg-update-delete">
+                                A successful response MUST have 204 (No Content) status.
+                            </span>
                             The retrieve operation is specified as `deleteTD` property in
                             <a href="#directory-thing-description">Directory's Thing Description</a>.
                         </p>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,17 @@
                     } ]
                 }],
         localBiblio : {
-           /// none yet
+            "REST-IOT" : {
+                  title: "RESTful Design for Internet of Things System"
+                , href: "https://tools.ietf.org/id/draft-keranen-t2trg-rest-iot-05.html"
+                , authors:  [
+                    "A. Keranen"
+                  , "M. Kovatsch"
+                  , "K. Hartke"
+                  ]
+                , publisher: "IETF"
+                , date: "14 September 2017"
+            }
         }
     };
 </script>
@@ -261,6 +271,56 @@ img.wot-diagram {
                     Manage existing records.
                     Basically CRUD operations on TD records.
                     </p>
+                    <p>
+                        The Registration API uses the HTTP [[?RFC7231]] protocol and provides a RESTful
+                        design inline with [[?REST-IOT]]. The serialization format for all request and
+                        response bodies is JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax to support
+                        extensions and semantic processing.
+                    </p>
+
+                    <h5>Create a TD</h5>
+                    <p>
+                        The API allows registration of a TD object passed as request body.
+                        A TD which is identified with an `id` attribute (known TD) is handled 
+                        differently with one that has no `id` (anonymous TD).
+                    </p>
+                    <p>
+                        A known TD is submitted to the directory using an HTTP `PUT` request at a  
+                        unique target location specified in the path. Upon successful processing, the 
+                        server shall respond with a 201 (Created) status. Note: If the target location 
+                        corresponds to an existing TD, the request shall instead proceed as an Update 
+                        operation.
+                    </p>
+                    <p>
+                        An anonymous TD is submitted to the directory using an HTTP `POST` request. 
+                        Upon successful processing, the server shall respond with a 201 (Created) status
+                        and a Location header containing an identifier for the TD.
+                    </p>
+                    <h5>Read a TD</h5>
+                    <p>
+                        A TD is retrieved from the directory using an HTTP `GET` request. The request
+                        should include the identifier of the TD as part of the path. A successful response
+                        shall contain the TD in body and have a 200 (OK) status.
+                    </p>
+                    <h5>Update a TD</h5>
+                    <p>
+                        A modified TD replaces an existing when submitted using an HTTP `PUT` request
+                        to the location corresponding to the existing TD. Upon success, the server
+                        responds with a 204 (No Content) status.
+                    </p>
+                    <p>
+                        A TD is partially modified when the modified parts are submitted using an HTTP `PATCH`
+                        request. The modified parts must conform to the original TD structure and may include
+                        other existing parts of the TD. Upon success, the server responds with a 204 (No Content)
+                        status.
+                    </p>
+                    <h5>Delete a TD</h5>
+                    <p>
+                        A TD is removed from the directory using an HTTP `DELETE` request. The request
+                        should include the identifier of the TD as part of the path. A successful response
+                        shall have a 204 (No Content) status.
+                    </p>
+
                 </section>
                 <section id="exploration-directory-api-management" class="normative">
                     <h4>Management</h4>

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ img.wot-diagram {
             </dd>
             <dt><dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>
             </dt>
-            <dd>A Thing Description without identifier (`id` attribute).
+            <dd>A Thing Description without an identifier (`id` attribute).
             </dd>
         </dl>
     </section>
@@ -289,32 +289,44 @@ img.wot-diagram {
                 
                 <aside class="example" id="directory-thing-description" title="Thing Description of the Directory">
                     <pre><div data-include='directory.td.json'></div></pre>
+
+                    <p class="ednote" title="Normative JSON Block">
+                        Need to add a css class for normative code blocks, instead of using the `example` class.
+                    </p>
+                    <p class="ednote" title="ID Type">
+                        The `id` variable need to have a defined type for semantic association with TD's `id` attribute.
+                    </p>
+                    <p class="ednote" title="Scopes">
+                        The scopes may need to be more concrete to able to allow updates but prevent creation.
+                    </p>
+                    
                 </aside>
+
                 <section id="exploration-directory-api-registration" class="normative">
                     <h4>Registration</h4>
-                    <p class="ednote">
-                        Must define a schema for error responses:
-                        [[?RFC7807]] may be a good option.
-                        
-                        <br>Should error objects be JSON-LD?
+                    <p class="ednote" title="Schema for error objects">
+                        [[?RFC7807]] may be a good option.<br>
+                        Should error objects be JSON-LD?
                     </p>
                     <p>
                         The Registration API is a RESTful HTTP API in accordance with the recommendations
                         defined in [[?RFC7231]] and [[?REST-IOT]].
-                        <span class="rfc2119-assertion" id="tdd-default-representation">
+                        <span class="rfc2119-assertion" id="tdd-reg-default-representation">
                             The default serialization format for all request and response bodies MUST be
                             JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax to support extensions and semantic
                             processing.
                         </span>
-                        <span class="rfc2119-assertion" id="tdd-additional-representation">
+                        <span class="rfc2119-assertion" id="tdd-reg-additional-representation">
                             Directories MAY accept additional representations based on request's indicated
                             Content-Type or Content-Encoding, and provide additional representations through
                             server-driven content negotiation.
                         </span>
                     </p>
                     <p>
-                        The Registration API MUST provide create, retrieve, update, delete (CRUD) interfaces 
-                        based on the following specification:
+                        <span class="rfc2119-assertion" id="tdd-reg-operations">
+                            The Registration API MUST provide create, retrieve, update, delete (CRUD) interfaces 
+                            based on the following specification:
+                        </span>
                     </p>
 
                     <dl><dt>Create a TD:</dt><dd>
@@ -367,6 +379,11 @@ img.wot-diagram {
                         </p>
                       
                     </dd></dl>
+
+                    <p class="ednote" title="Deduplication">
+                        The server should employ a mechanism to eliminate duplication of TDs submitted with
+                        a `POST` request. The spec need to have recommendations on how to perform this.
+                    </p>
                     
                     <dl><dt>Retrieve a TD:</dt><dd>
                         <p>

--- a/index.html
+++ b/index.html
@@ -595,12 +595,7 @@ img.wot-diagram {
             </section>
         </section>
     </section>
-    <section id="exploration-mech" class="normative">
-        <h1>Exploration Mechanisms</h1>
-        <p>
-            To do.
-        </p>
-    </section>
+
     <section id="security-considerations" class="informative">
         <h1>Security and Privacy Considerations</h1>
         <p>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,18 @@
                   ]
                 , publisher: "IETF"
                 , date: "14 September 2017"
-            }
+            },
+            "WOT-SECURITY-GUIDELINES" : {
+                title: "Web of Things (WoT) Security and Privacy Guidelines"
+                //, href: "https://www.w3.org/TR/wot-security/"
+                , href: "https://w3c.github.io/wot-security/"
+                , authors:  [
+                  , "Michael McCool"
+                  , "Elena Reshetova"
+                  ]
+                , publisher: "W3C"
+                , date: "March 2019"
+                }
         }
     };
 </script>
@@ -138,6 +149,10 @@ img.wot-diagram {
             <dd>A directory service with a prescribed API that allows the 
             registration, management, and search of a database of Thing Descriptions.
             Note that the acronym should be TDD, not TD, to avoid confusion with Thing Descriptions (TDs).
+            </dd>
+            <dt><dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>
+            </dt>
+            <dd>A Thing Description without identifier (`id` attribute).
             </dd>
         </dl>
     </section>
@@ -263,63 +278,187 @@ img.wot-diagram {
             </section>
             <section id="exploration-directory-api" class="normative">
                 <h3>Directory Service API</h3>
-                <p>API of directory service.
-                </p>
+                <span class="rfc2119-assertion" id="tdd-secure-protocols"> 
+                    The Directory APIs MUST use secure protocols guaranteeing 
+                    <a href="https://www.w3.org/TR/wot-security/#dfn-system-user-data">System User Data</a> 
+                    authenticity and confidentiality (see [[?WOT-SECURITY-GUIDELINES]]).
+                </span>
+                <span class="rfc2119-assertion" id="tdd-https"> 
+                    All HTTP APIs MUST be exposed over HTTPS (HTTP Over TLS).
+                </span>
+                
+                <aside class="example" id="directory-thing-description" title="Thing Description of the Directory">
+                    <pre><div data-include='directory.td.json'></div></pre>
+                </aside>
                 <section id="exploration-directory-api-registration" class="normative">
                     <h4>Registration</h4>
-                    <p>Sub-API to register a TD (or a link).
-                    Manage existing records.
-                    Basically CRUD operations on TD records.
+                    <p class="ednote">
+                        Must define a schema for error responses:
+                        [[?RFC7807]] may be a good option.
+                        
+                        <br>Should error objects be JSON-LD?
                     </p>
                     <p>
-                        The Registration API uses the HTTP [[?RFC7231]] protocol and provides a RESTful
-                        design inline with [[?REST-IOT]]. The serialization format for all request and
-                        response bodies is JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax to support
-                        extensions and semantic processing.
+                        The Registration API is a RESTful HTTP API in accordance with the recommendations
+                        defined in [[?RFC7231]] and [[?REST-IOT]]. The default serialization format for 
+                        all request and response bodies is JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax
+                        to support extensions and semantic processing. The Registration API must 
+                        provide create, retrieve, update, delete (CRUD) interfaces based on the following 
+                        specification:
                     </p>
 
-                    <h5>Create a TD</h5>
-                    <p>
-                        The API allows registration of a TD object passed as request body.
-                        A TD which is identified with an `id` attribute (known TD) is handled 
-                        differently with one that has no `id` (anonymous TD).
-                    </p>
-                    <p>
-                        A known TD is submitted to the directory using an HTTP `PUT` request at a  
-                        unique target location specified in the path. Upon successful processing, the 
-                        server shall respond with a 201 (Created) status. Note: If the target location 
-                        corresponds to an existing TD, the request shall instead proceed as an Update 
-                        operation.
-                    </p>
-                    <p>
-                        An anonymous TD is submitted to the directory using an HTTP `POST` request. 
-                        Upon successful processing, the server shall respond with a 201 (Created) status
-                        and a Location header containing an identifier for the TD.
-                    </p>
-                    <h5>Read a TD</h5>
-                    <p>
-                        A TD is retrieved from the directory using an HTTP `GET` request. The request
-                        should include the identifier of the TD as part of the path. A successful response
-                        shall contain the TD in body and have a 200 (OK) status.
-                    </p>
-                    <h5>Update a TD</h5>
-                    <p>
-                        A modified TD replaces an existing when submitted using an HTTP `PUT` request
-                        to the location corresponding to the existing TD. Upon success, the server
-                        responds with a 204 (No Content) status.
-                    </p>
-                    <p>
-                        A TD is partially modified when the modified parts are submitted using an HTTP `PATCH`
-                        request. The modified parts must conform to the original TD structure and may include
-                        other existing parts of the TD. Upon success, the server responds with a 204 (No Content)
-                        status.
-                    </p>
-                    <h5>Delete a TD</h5>
-                    <p>
-                        A TD is removed from the directory using an HTTP `DELETE` request. The request
-                        should include the identifier of the TD as part of the path. A successful response
-                        shall have a 204 (No Content) status.
-                    </p>
+                    <dl><dt>Create a TD:</dt><dd>
+                        <p>
+                            The API must allow registration of a TD object passed as request body. The request
+                            should contain `application/td+json` Content-Type header. The TD object should be
+                            validated syntactically using the 
+                            <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                            [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                        </p>
+                        <p>
+                            A TD which is identified with an `id` attribute must be handled 
+                            differently with one that has no identifier (<a>Anonymous TD</a>). The create operations
+                            are specified as `createTD` action in 
+                            <a href="#directory-thing-description">Directory's Thing Description</a>
+                            and elaborated below:
+                        </p>
+                        <ul>
+                            <li>
+                                A TD is submitted to the directory using an HTTP `PUT` request at a  
+                                target location (HTTP path) containing the unique TD `id`. 
+                                Upon successful processing, the server shall respond with
+                                201 (Created) status.                             
+                                <br>Note: If the target location corresponds to an existing TD,
+                                the request shall instead proceed as an Update operation and respond
+                                the appropriate status code (see Update section).
+                            </li>
+                            <li>
+                                An <a>Anonymous TD</a> is submitted to the directory using an HTTP `POST` request. 
+                                Upon successful processing, the server shall respond with 201 (Created) status
+                                and a Location header containing a system-generated identifier for the TD.
+                                The identifier should be a Version 4 UUID URN [[RFC4122]].
+                            </li>
+                        </ul>
+
+                        <p>
+                            Error responses:
+                            <ul>
+                                <li>
+                                    400 (Bad Request): Invalid serialization or TD.
+                                    This is accompanied by an appropriate response message.
+                                </li>
+                                <li>
+                                    401 (Unauthorized): No authentication.
+                                </li>
+                                <li>
+                                    403 (Forbidden): Insufficient rights to the resource.
+                                </li>
+                            </ul>
+                        </p>
+                      
+                    </dd></dl>
+                    
+                    <dl><dt>Retrieve a TD:</dt><dd>
+                        <p>
+                            A TD must be retrieved from the directory using an HTTP `GET` request. The request
+                            must include the identifier of the TD as part of the path. A successful response
+                            shall have 200 (OK) status, contain `application/td+json` Content-Type header,
+                            and the requested TD in body. The retrieve operation is specified as `retrieveTD` 
+                            property in 
+                            <a href="#directory-thing-description">Directory's Thing Description</a>.
+                        </p>
+
+                        <p>
+                            Error responses:  
+                            <ul>
+                                <li>
+                                    404 (Not Found): TD with the given `id` not found.
+                                </li>
+                                <li>
+                                    401 (Unauthorized): No authentication.
+                                </li>
+                                <li>
+                                    403 (Forbidden): Insufficient rights to the resource.
+                                </li>
+                            </ul>
+                        </p>
+                    </dd></dl>
+                    
+                    <dl><dt>Update a TD:</dt><dd>
+                        <p>
+                            The API must allow modifications to existing TDs as full replacement or partial updates.
+                            The request should contain `application/td+json` Content-Type header. The update operations
+                            are described below:
+                        </p>
+
+                        <ul>
+                            <li>
+                                A modified TD must replace an existing when submitted using an HTTP `PUT` request
+                                to the location corresponding to the existing TD. The TD object should be
+                                validated syntactically using the 
+                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                                Upon success, the server responds with 204 (No Content) status. 
+                                This operation is specified as `updateTD` property in 
+                                <a href="#directory-thing-description">Directory's Thing Description</a>.
+                                <br>Note: If the target location does not correspond to an existing TD,
+                                the request shall instead proceed as a Create operation and respond
+                                the appropriate status code (see Create section).
+                            </li>
+                            <li>
+                                A TD must be partially modified when the modified parts are submitted using an 
+                                HTTP `PATCH` request. The modified parts must conform to the original TD structure 
+                                and may include other existing parts of the TD. After applying the modifications,
+                                the TD object should be validated syntactically using the 
+                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
+                                Upon success, the server responds with a 204 (No Content) status.
+                                The partial update operation is specified as `updatePartialTD` property in 
+                                <a href="#directory-thing-description">Directory's Thing Description</a>.
+                            </li>
+                        </ul>
+
+                        <p>
+                            Error responses:
+                            <ul>
+                                <li>
+                                    400 (Bad Request): Invalid serialization or TD.
+                                    This is accompanied by an appropriate response message.
+                                </li>
+                                <li>
+                                    401 (Unauthorized): Rejecting a request without appropriate authentication.
+                                </li>
+                                <li>
+                                    403 (Forbidden): Rejecting a request due to insufficient rights to the resource.
+                                </li>
+                            </ul>
+                        </p>
+                    </dd></dl>
+                    
+                    <dl><dt>Delete a TD:</dt><dd>
+                        <p>
+                            A TD must be removed from the directory using an HTTP `DELETE` request.
+                            The request should include the identifier of the TD as part of the path. 
+                            A successful response shall have 204 (No Content) status.
+                            The retrieve operation is specified as `deleteTD` property in
+                            <a href="#directory-thing-description">Directory's Thing Description</a>.
+                        </p>
+
+                        <p>
+                            Error responses:
+                            <ul>
+                                <li>
+                                    404 (Not Found): TD with the given `id` not found.
+                                </li>
+                                <li>
+                                    401 (Unauthorized): No authentication.
+                                </li>
+                                <li>
+                                    403 (Forbidden): Insufficient rights to the resource.
+                                </li>
+                            </ul>
+                        </p>
+                    </dd></dl>
 
                 </section>
                 <section id="exploration-directory-api-management" class="normative">

--- a/index.html
+++ b/index.html
@@ -300,23 +300,33 @@ img.wot-diagram {
                     </p>
                     <p>
                         The Registration API is a RESTful HTTP API in accordance with the recommendations
-                        defined in [[?RFC7231]] and [[?REST-IOT]]. The default serialization format for 
-                        all request and response bodies is JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax
-                        to support extensions and semantic processing. The Registration API must 
-                        provide create, retrieve, update, delete (CRUD) interfaces based on the following 
-                        specification:
+                        defined in [[?RFC7231]] and [[?REST-IOT]].
+                        <span class="rfc2119-assertion" id="tdd-default-representation">
+                            The default serialization format for all request and response bodies MUST be
+                            JSON, with JSON-LD 1.1 [[?JSON-LD11]] syntax to support extensions and semantic
+                            processing.
+                        </span>
+                        <span class="rfc2119-assertion" id="tdd-additional-representation">
+                            Directories MAY accept additional representations based on request's indicated
+                            Content-Type or Content-Encoding, and provide additional representations through
+                            server-driven content negotiation.
+                        </span>
+                    </p>
+                    <p>
+                        The Registration API MUST provide create, retrieve, update, delete (CRUD) interfaces 
+                        based on the following specification:
                     </p>
 
                     <dl><dt>Create a TD:</dt><dd>
                         <p>
-                            The API must allow registration of a TD object passed as request body. The request
-                            should contain `application/td+json` Content-Type header. The TD object should be
-                            validated syntactically using the 
+                            The API MUST allow registration of a TD object passed as request body. The request
+                            SHOULD contain `application/td+json` Content-Type header for JSON serialization of TD.
+                            The TD object SHOULD be validated syntactically using the 
                             <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
                             [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
                         </p>
                         <p>
-                            A TD which is identified with an `id` attribute must be handled 
+                            A TD which is identified with an `id` attribute MUST be handled 
                             differently with one that has no identifier (<a>Anonymous TD</a>). The create operations
                             are specified as `createTD` action in 
                             <a href="#directory-thing-description">Directory's Thing Description</a>
@@ -324,19 +334,19 @@ img.wot-diagram {
                         </p>
                         <ul>
                             <li>
-                                A TD is submitted to the directory using an HTTP `PUT` request at a  
+                                A TD MUST be submitted to the directory using an HTTP `PUT` request at a  
                                 target location (HTTP path) containing the unique TD `id`. 
-                                Upon successful processing, the server shall respond with
+                                Upon successful processing, the server MUST respond with
                                 201 (Created) status.                             
                                 <br>Note: If the target location corresponds to an existing TD,
                                 the request shall instead proceed as an Update operation and respond
                                 the appropriate status code (see Update section).
                             </li>
                             <li>
-                                An <a>Anonymous TD</a> is submitted to the directory using an HTTP `POST` request. 
-                                Upon successful processing, the server shall respond with 201 (Created) status
+                                An <a>Anonymous TD</a> MUST be submitted to the directory using an HTTP `POST` request. 
+                                Upon successful processing, the server MUST respond with 201 (Created) status
                                 and a Location header containing a system-generated identifier for the TD.
-                                The identifier should be a Version 4 UUID URN [[RFC4122]].
+                                The identifier SHOULD be a Version 4 UUID URN [[RFC4122]].
                             </li>
                         </ul>
 
@@ -360,9 +370,9 @@ img.wot-diagram {
                     
                     <dl><dt>Retrieve a TD:</dt><dd>
                         <p>
-                            A TD must be retrieved from the directory using an HTTP `GET` request. The request
-                            must include the identifier of the TD as part of the path. A successful response
-                            shall have 200 (OK) status, contain `application/td+json` Content-Type header,
+                            A TD MUST be retrieved from the directory using an HTTP `GET` request. The request
+                            MUST include the identifier of the TD as part of the path. A successful response
+                            MUST have 200 (OK) status, contain `application/td+json` Content-Type header,
                             and the requested TD in body. The retrieve operation is specified as `retrieveTD` 
                             property in 
                             <a href="#directory-thing-description">Directory's Thing Description</a>.
@@ -386,34 +396,36 @@ img.wot-diagram {
                     
                     <dl><dt>Update a TD:</dt><dd>
                         <p>
-                            The API must allow modifications to existing TDs as full replacement or partial updates.
-                            The request should contain `application/td+json` Content-Type header. The update operations
-                            are described below:
+                            The API MUST allow modifications to existing TDs as full replacement or partial updates.
+                            The request SHOULD contain `application/td+json` Content-Type header for JSON serialization
+                            of TD. The update operations are described below:
                         </p>
 
                         <ul>
                             <li>
-                                A modified TD must replace an existing when submitted using an HTTP `PUT` request
-                                to the location corresponding to the existing TD. The TD object should be
+                                A modified TD MUST replace an existing when submitted using an HTTP `PUT` request
+                                to the location corresponding to the existing TD. The TD object SHOULD be
                                 validated syntactically using the 
                                 <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
                                 [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
-                                Upon success, the server responds with 204 (No Content) status. 
+                                Upon success, the server MUST respond with 204 (No Content) status. 
                                 This operation is specified as `updateTD` property in 
                                 <a href="#directory-thing-description">Directory's Thing Description</a>.
                                 <br>Note: If the target location does not correspond to an existing TD,
                                 the request shall instead proceed as a Create operation and respond
-                                the appropriate status code (see Create section).
+                                the appropriate status code (see Create section). In other words, an HTTP `PUT`
+                                request acts as a create or update operation. An HTTP `PATCH` may be used for
+                                an update-only operation.
                             </li>
                             <li>
-                                A TD must be partially modified when the modified parts are submitted using an 
-                                HTTP `PATCH` request. The modified parts must conform to the original TD structure 
+                                An existing TD MUST be partially modified when the modified parts are submitted using an 
+                                HTTP `PATCH` request. The modified parts MUST conform to the original TD structure 
                                 and may include other existing parts of the TD. After applying the modifications,
-                                the TD object should be validated syntactically using the 
+                                the TD object SHOULD be validated syntactically using the 
                                 <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
                                 [[WoT-Thing-Description]]. <!-- any way to add anchor to citations? -->
-                                Upon success, the server responds with a 204 (No Content) status.
-                                The partial update operation is specified as `updatePartialTD` property in 
+                                Upon success, the server MUST respond with a 204 (No Content) status.
+                                This operation is specified as `updatePartialTD` property in 
                                 <a href="#directory-thing-description">Directory's Thing Description</a>.
                             </li>
                         </ul>
@@ -424,6 +436,9 @@ img.wot-diagram {
                                 <li>
                                     400 (Bad Request): Invalid serialization or TD.
                                     This is accompanied by an appropriate response message.
+                                </li>
+                                <li>
+                                    404 (Not Found): TD with the given `id` not found (for `PATCH` only). 
                                 </li>
                                 <li>
                                     401 (Unauthorized): Rejecting a request without appropriate authentication.
@@ -439,7 +454,7 @@ img.wot-diagram {
                         <p>
                             A TD must be removed from the directory using an HTTP `DELETE` request.
                             The request should include the identifier of the TD as part of the path. 
-                            A successful response shall have 204 (No Content) status.
+                            A successful response MUST have 204 (No Content) status.
                             The retrieve operation is specified as `deleteTD` property in
                             <a href="#directory-thing-description">Directory's Thing Description</a>.
                         </p>


### PR DESCRIPTION
Added a draft for the Registration API.

- Not sure if it should be more specific and also specify the API endpoint specifications or just point to the action/property name of the directory TD. 
- Should TD's `id` be mutable inside a directory? Apart from privacy risks (see #39), this complicates the API design.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/38.html" title="Last updated on Aug 4, 2020, 9:54 AM UTC (97c2123)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/38/5ff4fe9...farshidtz:97c2123.html" title="Last updated on Aug 4, 2020, 9:54 AM UTC (97c2123)">Diff</a>