### PR TITLE
Add additional security schemes to directory TD

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -10,15 +10,41 @@
             "scheme": "oauth2",
             "flow": "code",
             "authorization": "https://auth.example.com/authorization",
+            "scopes": [
+                "write",
+                "read",
+                "search"
+            ]
+        },
+        "oauth2_client": {
+            "scheme": "oauth2",
+            "flow": "client",
             "token": "https://auth.example.com/token",
             "scopes": [
                 "write",
                 "read",
                 "search"
             ]
+        },
+        "oauth2_device": {
+            "scheme": "oauth2",
+            "flow": "device",
+            "scopes": [
+                "write",
+                "read",
+                "search"
+            ]
+        },
+        "combination": {
+            "scheme": "combination",
+            "oneOf": [
+                "oauth2_code",
+                "oauth2_client",
+                "oauth2_device"
+            ]
         }
     },
-    "security": "oauth2_code",
+    "security": "combination",
     "base": "https://tdd.example.com",
     "actions": {
         "createTD": {

--- a/directory.td.json
+++ b/directory.td.json
@@ -10,6 +10,7 @@
             "scheme": "oauth2",
             "flow": "code",
             "authorization": "https://auth.example.com/authorization",
+            "token": "https://auth.example.com/token",
             "scopes": [
                 "write",
                 "read",
@@ -29,6 +30,8 @@
         "oauth2_device": {
             "scheme": "oauth2",
             "flow": "device",
+            "authorization": "https://auth.example.com/device_authorization",
+            "token": "https://auth.example.com/token",
             "scopes": [
                 "write",
                 "read",


### PR DESCRIPTION
Added client and device security schemes based on the proposed combination scheme (https://github.com/w3c/wot-thing-description/pull/944). 

While adding those, I started to have doubts in the recently merged spec (https://github.com/w3c/wot-thing-description/pull/927) about what endpoints are necessary for code and device flows.

In this PR, I included what is technically **required** by a user to interact with a thing based on the TD. In particular: 
- In code flow, the user only needs the `authorization` endpoint. The `token` endpoint is required by the device to internally exchange the code with an access token. Why MUST the `token` endpoint be included and given to the consumer in device's metadata?
- In device flow, the device talks to `authorization` (oauth2 device authorization) endpoint internally, gets a `verification_uri` and `user_code` from the server and displays these to the user. The user follows the `verification_uri` to authenticate/authorize. At the same time, the device starts polling the `token` endpoint to receive the access token. Why MUST the `authorization` and `token` endpoints be included and given to the consumer in device's metadata?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/50.html" title="Last updated on Aug 18, 2020, 5:37 PM UTC (e8470f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/50/d964f85...farshidtz:e8470f2.html" title="Last updated on Aug 18, 2020, 5:37 PM UTC (e8470f2)">Diff</a>