### PR TITLE
Add description of the notification API

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -154,10 +154,6 @@
         "registration": {
             "description": "TD registration events",
             "uriVariables": {
-                "td_id": {
-                    "title": "Identifier of TD in directory",
-                    "type": "string"
-                },
                 "type": {
                     "title": "Event type",
                     "type": "string",
@@ -166,24 +162,77 @@
                         "updated_td",
                         "deleted_td"
                     ]
+                },
+                "td_id": {
+                    "title": "Identifier of TD in directory",
+                    "type": "string"
+                },
+                "include_changes": {
+                    "title": "Include TD changes inside event data",
+                    "type": "boolean"
                 }
-            }
-        },
-        "forms": [
-            {
-                "op": "subscribeevent",
-                "href": "/events{?type,td_id}",
-                "subprotocol": "sse",
-                "contentType": "text/event-stream",
-                "htv:headers": [
-                    {
-                        "description": "ID of the last event for reconnection",
-                        "htv:fieldName": "Last-Event-ID",
-                        "htv:fieldValue": ""
-                    }
-                ],
-                "scopes": "notifications"
-            }
-        ]
+            },
+            "forms": [
+                {
+                    "op": "subscribeevent",
+                    "href": "/events{?type,td_id,include_changes}",
+                    "subprotocol": "sse",
+                    "contentType": "text/event-stream",
+                    "htv:headers": [
+                        {
+                            "description": "ID of the last event for reconnection",
+                            "htv:fieldName": "Last-Event-ID",
+                            "htv:fieldValue": ""
+                        }
+                    ],
+                    "data": {
+                        "oneOf":[
+                            {
+                                "type": "object",
+                                "description": "The schema of event data",
+                                "properties": {
+                                    "td_id": {
+                                        "type": "string",
+                                        "format": "iri-reference",
+                                        "description": "Identifier of TD in directory"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "description": "The schema of create event data including the created TD",
+                                "properties": {
+                                    "td_id": {
+                                        "type": "string",
+                                        "format": "iri-reference",
+                                        "description": "Identifier of TD in directory"
+                                    },
+                                    "td": {
+                                        "type": "object",
+                                        "description": "The created TD in a create event"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "description": "The schema of the update event data including the updates to TD",
+                                "properties": {
+                                    "td_id": {
+                                        "type": "string",
+                                        "format": "iri-reference",
+                                        "description": "Identifier of TD in directory"
+                                    },
+                                    "td_updates": {
+                                        "type": "object",
+                                        "description": "The partial TD composed of modified TD parts in an update event" 
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "scopes": "notifications"
+                }
+            ]
+        }
     }
 }

--- a/directory.td.json
+++ b/directory.td.json
@@ -154,17 +154,17 @@
         "registration": {
             "description": "TD registration events",
             "uriVariables": {
-                "id": {
-                    "title": "Thing Description ID",
+                "td_id": {
+                    "title": "Identifier of TD in directory",
                     "type": "string"
                 },
-                "types": {
-                    "title": "Event Type",
+                "type": {
+                    "title": "Event type",
                     "type": "string",
                     "enum": [
-                        "createdTD",
-                        "updatedTD",
-                        "deletedTD"
+                        "created_td",
+                        "updated_td",
+                        "deleted_td"
                     ]
                 }
             }
@@ -172,9 +172,16 @@
         "forms": [
             {
                 "op": "subscribeevent",
-                "href": "https://tdd.example.com/events{/id}{?type}",
+                "href": "/events{?type,td_id}",
                 "subprotocol": "sse",
                 "contentType": "text/event-stream",
+                "htv:headers": [
+                    {
+                        "description": "ID of the last event for reconnection",
+                        "htv:fieldName": "Last-Event-ID",
+                        "htv:fieldValue": ""
+                    }
+                ],
                 "scopes": "notifications"
             }
         ]

--- a/directory.td.json
+++ b/directory.td.json
@@ -149,5 +149,34 @@
                 }
             ]
         }
+    },
+    "events": {
+        "registration": {
+            "description": "TD registration events",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string"
+                },
+                "types": {
+                    "title": "Event Type",
+                    "type": "string",
+                    "enum": [
+                        "createdTD",
+                        "updatedTD",
+                        "deletedTD"
+                    ]
+                }
+            }
+        },
+        "forms": [
+            {
+                "op": "subscribeevent",
+                "href": "https://tdd.example.com/events{/id}{?type}",
+                "subprotocol": "sse",
+                "contentType": "text/event-stream",
+                "scopes": "notifications"
+            }
+        ]
     }
 }

--- a/index.html
+++ b/index.html
@@ -562,8 +562,110 @@ img.wot-diagram {
                 </section>
                 <section id="exploration-directory-api-notification" class="normative">
                     <h4>Notification</h4>
-                    <p>Sub-API to notify clients of events, such as updates to TDs.
+                    <p>The Notification API is to notify clients about the changes
+                        to Thing Descriptions maintained within the directory.
+                        <span class="rfc2119-assertion" id="tdd-notification-sse">
+                            The Notification API MUST follow the Server-Sent Events [[EVENTSOURCE]]
+                            specifications to serve events to clients. 
+                        </span>
+                        In particular, the server responds to successful requests with 200 (OK) status
+                        and `text/event-stream` Content Type. Re-connecting clients may continue from
+                        the last event by providing the last event ID as `Last-Event-ID` header value.
+                        This API is specified as `registration` event in [[[#directory-thing-description]]].
                     </p>
+
+                    <dl>
+                        <dt>Event Types</dt>
+                        <dd>
+                            <span class="rfc2119-assertion" id="tdd-notification-event-types">
+                                The server MUST produce events for creation, update, and deletion of
+                                Thing Descriptions represented by `created_td`, `updated_td`, `deleted_td`
+                                keywords respectively.
+                            </span>
+                        </dd>
+
+                        <dt>Event Filtering</dt>
+                        <dd>
+                            The API supports server-side filtering of events to reduce resource consumption
+                            by delivering only the events required by clients.
+                            The filtering is based on query parameters passed to the server at 
+                            connection time. The filtering behavior is described below:
+                            <ul>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-filter-type">
+                                        The server MUST support event filtering based on the 
+                                        event types passed as one or more `type` query parameters.
+                                    </span>
+                                    For example, in response to query `?type=created_td&type=deleted_td`,
+                                    the server must only deliver events of types `created_td` and `deleted_td`.
+                                    At the absence of any `type` query parameter, the server must deliver all
+                                    types of events.
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-filter-tdid">
+                                        The server MUST support event filtering based on the 
+                                        Thing Description identifier passed as one or more `td_id` query parameters.
+                                    </span>
+                                    For example, the query `?type=updated_td&td_id=urn:example:1234` must
+                                    result in `updated_td` events for the TD identified with `urn:example:1234`.
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-filter-search">
+                                        The server MAY support event filtering based on the 
+                                        search expressions passed as one of `jsonpath`, `xpath`, 
+                                        or `sparql` query parameters.
+                                    </span>
+                                    <span class="rfc2119-assertion" id="tdd-notification-filter-search-unsupported">
+                                        If the server does not support a given search query parameter, it
+                                        MUST reject the request with 501 (Not Implemented) status.
+                                    </span>
+                                </li>
+                            </ul>
+                        </dd>
+                        <dt>Event Data</dt>
+                        <dd>
+                            <span class="rfc2119-assertion" id="tdd-notification-data">
+                                The event data MUST contain the JSON serialization of the event object.
+                            </span>
+                            The event data object is defined by the following rules:
+                            <ul>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-tdid">
+                                        The event data object MUST at least include the identifier of the
+                                        TD created, updated, or deleted at that event as value of `td_id` field.
+                                    </span>
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-createdtd">
+                                        When `include_changes` query parameter is set to `true`, the create
+                                        event data object MAY include the created TD as the value of `created_td`
+                                        field.
+                                    </span>
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-tdupdates">
+                                        When `include_changes` query parameter is set to `true`, the update
+                                        event data object MAY include the updated parts of the TD in
+                                        <a>Partial TD</a> form as the value of `td_updates` field.
+                                    </span>
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-change-unsupported">
+                                        When the server which does not support the inclusion of changes inside event
+                                        data object is requested with a `include_changes` query parameter, it MUST
+                                        reject the request with 501 (Not Implemented) status.
+                                    </span>
+                                </li>
+                            </ul>
+                            
+                            
+                            
+                            
+
+                        </dd>
+                    </dl>
+                    
+
                 </section>
                 <section id="exploration-directory-api-search" class="normative">
                     <h4>Search</h4>

--- a/index.html
+++ b/index.html
@@ -651,19 +651,24 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-change-unsupported">
-                                        When the server which does not support the inclusion of changes inside event
+                                        When a server which does not support the inclusion of changes inside event
                                         data object is requested with a `include_changes` query parameter, it MUST
                                         reject the request with 501 (Not Implemented) status.
                                     </span>
                                 </li>
                             </ul>
-                            
-                            
-                            
-                            
-
                         </dd>
                     </dl>
+
+                    <p class="ednote" title="SSE Authorization Header">
+                        Some early SSE implementations (including HTML5 EventSource) do not allow
+                        setting custom headers in the initial HTTP request. Authorization header 
+                        is required in few OAuth2 flows and passing it as a query parameter is
+                        <a href="https://tools.ietf.org/html/rfc6750#section-2.3">not advised</a>.
+
+                        There are polyfills for browsers and modern libraries which allow 
+                        setting Authorization header.
+                    </p>
                     
 
                 </section>


### PR DESCRIPTION
The event API based on SSE, as discussed in #42.

- I am defining only one event affordance called `registration` for three event types (createdTD, updatedTD, deletedTD) because this enables subscription to a single or multiple events in a single SSE stream. Alternatively, we can separate them to three event affordances and use multiple SSE streams; when using HTTP/2, the streams could get multiplexed over the same TCP connection.

- Both `id` and `types` are optional; without them the authorized user can subscribe to all events on all TDs.

- Other query parameters may be supported by passing query expressions (e.g. jsonpath, sparql), if required per [this comment](https://github.com/w3c/wot-discovery/issues/28#issuecomment-647683425).

TODO:
- [x] Add events API to TD.
- [x] Add assertion: The event type must be used by the server to deliver only requested events, regardless of SSE's native client-side event filtering.
- [x] Add assertion: The server should keep a history of events and deliver them to re-connecting clients (based on the provided SSE's `lastEventId`) -> included in SSE specs.
- [x] Change types to type
- [x] Describe the format of SSE `data`.
- [x] Describe the use of `Authorization` header. -> added editorial note as this may go to the security section.
- [x] Change TD `id` in query to something else to avoid confusion with event ID.
- [x] Change description of TD ID to "identifier of Thing Description in directory"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/51.html" title="Last updated on Sep 7, 2020, 1:23 PM UTC (26c7360)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/51/d964f85...farshidtz:26c7360.html" title="Last updated on Sep 7, 2020, 1:23 PM UTC (26c7360)">Diff</a>