### PR TITLE
Add Partial TD term to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,10 @@ img.wot-diagram {
            The WoT prefix is used to avoid ambiguity for terms that are
            (re)defined specifically for Web of Things concepts.</p>
         <dl>
+            <dt><dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>
+            </dt>
+            <dd>A Thing Description without an identifier (`id` attribute).
+            </dd>
             <dt><dfn data-lt="WoT Discovery">Discovery</dfn>
             </dt>
             <dd>In the WoT context, the process of finding and retrieving Thing metadata
@@ -222,9 +226,10 @@ img.wot-diagram {
             registration, management, and search of a database of Thing Descriptions.
             Note that the acronym should be TDD, not TD, to avoid confusion with Thing Descriptions (TDs).
             </dd>
-            <dt><dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>
+            <dt><dfn data-lt="WoT Partial Thing Description">Partial TD</dfn>
             </dt>
-            <dd>A Thing Description without an identifier (`id` attribute).
+            <dd>A data model partially conformant to the Thing Description schema by including 
+            only a subset of the attributes.
             </dd>
         </dl>
     </section>


### PR DESCRIPTION
This is useful because we can refer to it from different parts of the document, including for partial updates and update diffs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/61.html" title="Last updated on Sep 7, 2020, 3:21 PM UTC (342b301)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/61/99e093f...farshidtz:342b301.html" title="Last updated on Sep 7, 2020, 3:21 PM UTC (342b301)">Diff</a>