### PR TITLE
Editorial fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <title>Web of Things (WoT) Discovery</title>
 <script 
-    src="https://www.w3.org/Tools/respec/respec-w3c-common"
+    src="https://www.w3.org/Tools/respec/respec-w3c"
     class="remove"
     defer
 ></script>
@@ -174,7 +174,7 @@ img.wot-diagram {
            not appropriate.  
            At the same time, 
            use of existing standards for semantic data query, 
-           such as SPARQL [sparql], 
+           such as SPARQL [[SPARQL11-OVERVIEW]], 
            while potentially suitable for some advanced use cases, 
            might require to much effort for many anticipated IoT applications.
            Therefore in order to address more basic applications,
@@ -422,7 +422,7 @@ img.wot-diagram {
                 <h3>Directory Service API</h3>
                 The Directory APIs must use secure protocols guaranteeing 
                 <a href="https://www.w3.org/TR/wot-security/#dfn-system-user-data">System User Data</a> 
-                authenticity and confidentiality (see [[?WOT-SECURITY-GUIDELINES]]).
+                authenticity and confidentiality (see [[?WOT-SECURITY]]).
                 <span class="rfc2119-assertion" id="tdd-https"> 
                     The HTTP API MUST be exposed over HTTPS (HTTP Over TLS).
                 </span>


### PR DESCRIPTION
- Migrate respec profile from `w3c-common`(deprecated) to `w3c`.  See [respec w3c common migration guide](https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide).
- Fix broken reference of SPARQL and WoT Security & Privacy Guidelines.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-discovery/pull/70.html" title="Last updated on Sep 15, 2020, 1:04 AM UTC (a1f2a52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/70/bd99c48...k-toumura:a1f2a52.html" title="Last updated on Sep 15, 2020, 1:04 AM UTC (a1f2a52)">Diff</a>