### PR TITLE
[Editorial] remove deprecated configuration options, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,6 @@
         shortName : "wot-discovery",
         copyrightStart : 2017,
         group: "wg/wot",
-        //wg : "Web of Things Working Group",
-        //wgURI : "https://www.w3.org/WoT/WG/",
-        //wgPatentURI : "https://www.w3.org/2004/01/pp-impl/95969/status",
         wgPublicList : "public-wot-wg",
         github: {
             repoURL: "https://github.com/w3c/wot-discovery",

--- a/index.html
+++ b/index.html
@@ -20,9 +20,10 @@
         specStatus : "ED",
         shortName : "wot-discovery",
         copyrightStart : 2017,
-        wg : "Web of Things Working Group",
-        wgURI : "https://www.w3.org/WoT/WG/",
-        wgPatentURI : "https://www.w3.org/2004/01/pp-impl/95969/status",
+        group: "wot",
+        //wg : "Web of Things Working Group",
+        //wgURI : "https://www.w3.org/WoT/WG/",
+        //wgPatentURI : "https://www.w3.org/2004/01/pp-impl/95969/status",
         wgPublicList : "public-wot-wg",
         github: {
             repoURL: "https://github.com/w3c/wot-discovery",
@@ -56,24 +57,24 @@
                     key : "Contributors",
                     data : [ {
                         value : "In the GitHub repository",
-                        href : "https://github.com/w3c/wot-architecture/graphs/contributors"
+                        href : "https://github.com/w3c/wot-discovery/graphs/contributors"
                     } ]
                 }],
         localBiblio : {
             "REST-IOT" : {
-                  title: "RESTful Design for Internet of Things System"
-                , href: "https://tools.ietf.org/id/draft-keranen-t2trg-rest-iot-05.html"
+                  title: "RESTful Design for Internet of Things Systems"
+                , href: "https://tools.ietf.org/html/draft-irtf-t2trg-rest-iot-06"
                 , authors:  [
-                    "A. Keranen"
-                  , "M. Kovatsch"
-                  , "K. Hartke"
+                    "Ari Keranen"
+                  , "Matthias Kovatsch"
+                  , "Klaus Hartke"
                   ]
                 , publisher: "IETF"
-                , date: "14 September 2017"
+                , date: "11 May 2020"
             },
             "CoRE-RD" : {
                   title: "CoRE Resource Directory"
-                , href: "https://www.ietf.org/id/draft-ietf-core-resource-directory-25.txt"
+                , href: "https://tools.ietf.org/html/draft-ietf-core-resource-directory-25"
                 , authors: [
                     "Zach Shelby"
                   , "Michael Koster"

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         specStatus : "ED",
         shortName : "wot-discovery",
         copyrightStart : 2017,
-        group: "wot",
+        group: "wg/wot",
         //wg : "Web of Things Working Group",
         //wgURI : "https://www.w3.org/WoT/WG/",
         //wgPatentURI : "https://www.w3.org/2004/01/pp-impl/95969/status",


### PR DESCRIPTION
- Add `group: "wg/wot"` in `respecConfig`. Configuration options `wg`, `wgURI`, `wgId`, `wgPatentURI`, and `wgPatentPolicy` are deprecated. (cf. [ReSpec Documentation](https://respec.org/docs/#group))
- Fix a link to Contributors.
- Update a reference entry of 'RESTful Design for Internet of Things Systems' to most recent version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-discovery/pull/73.html" title="Last updated on Sep 26, 2020, 1:44 AM UTC (0bb8d68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/73/d127614...k-toumura:0bb8d68.html" title="Last updated on Sep 26, 2020, 1:44 AM UTC (0bb8d68)">Diff</a>