### PR TITLE
Mark incomplete sections as editor's notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,9 @@ img.wot-diagram {
     </section>
     <section id="architecture" class="informative">
         <h1>Architecture</h1>
-        <p>Two-Phase approach.
+        <p class="ednote" title="Discovery Architecture Overview">
+        To do: an overview of the two-phase approach and its purpose, which is to support
+        controlled and authenticated access to metadata by authorized users only.
         </p>
     </section>
     <section id="introduction-mech" class="normative">
@@ -399,21 +401,25 @@ img.wot-diagram {
     </section>
     <section id="exploration-mech" class="normative">
         <h1>Exploration Mechanisms</h1>
-        <p>Description of supported explorations, and requirements for 
+        <p class="ednote" title="Exploration Mechanism Overview">
+        To do: Description of supported explorations, and requirements for 
         new exploration mechanisms.
         </p>
         <section id="exploration-self" class="normative">
             <h2>Self-description</h2>
-            <p>Mechanism for devices to self-describe, hosting their own TDs.
+            <p class="ednote" title="Self-Description Overview">
+            To do: Describe mechanisms for devices to self-describe, hosting their own TDs.
             </p>
         </section>
         <section id="exploration-directory" class="normative">
             <h2>Directory</h2>
-            <p>Mechanism for TDs to be hosted in a searchable directory service.
+            <p class="ednote" title="Directory Overview">
+            To do: Describe mechanisms for TDs to be hosted in a searchable directory service.
             </p>
             <section id="exploration-directory-info" class="normative">
                 <h3>Information Model</h3>
-                <p>Description of conceptual data organization in a directory.
+                <p class="ednote" title="Directory Information Model">
+                To Do: Formal definition of information contained in a directory and its organization.
                 </p>
             </section>
             <section id="exploration-directory-api" class="normative">
@@ -934,21 +940,32 @@ img.wot-diagram {
             privacy issues, see the <em>WoT Security and Privacy Guidelines</em>
             specification [[?WOT-SECURITY]].
         </p>
+        <p class="ednote" title="Discovery Security and Privacy Concerns and Mitigations">
+        To do, some discussion of general security and privacy concerns and mitigations.
+        Note that the architecture above is designed to address many such points, for
+        example the two-phase approach and "authorization before metadata release"
+        principles, so this would be 
+        a summary and a recap.
+        </p>
     </section>
 
     <section id="changes" class="appendix">
       <h1>Recent Specification Changes</h1>
+<!--
       <h2 id="changes-from-first-draft">Changes from First Draft</h2>
+-->
       <ul>
-      <li>Initial framework.</li>
+      <li>Initial draft.</li>
       </ul>
     </section>
 
     <section id="acknowledgements" class="appendix normative">
         <h1>Acknowledgments</h1>
+<!--
         <p>Special thanks to X, Y, and Z
            for their contributions to this document.
         </p>
+-->
         <p>
             Many thanks to the W3C staff and all other active Participants of the W3C Web
             of Things Interest Group (WoT IG) and Working Group (WoT WG) for their


### PR DESCRIPTION
As discussed in the call 2020.09.28, in preparation for FPWD, mark incomplete sections with editor's notes.   Also some small cleanup, e.g. commenting out some boilerplate thanking people for contributions at the end (we can bring it back when we're ready).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/75.html" title="Last updated on Sep 28, 2020, 3:22 PM UTC (283f638)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/75/a443536...mmccool:283f638.html" title="Last updated on Sep 28, 2020, 3:22 PM UTC (283f638)">Diff</a>