### PR TITLE
Fix respec errors due to references

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,19 @@
                 , publisher: "IETF"
                 , date: "12 July 2020"
                 , status: "DRAFT",
+            },
+            "wot-usecases" : {
+                  title: "Web of Things (WoT): Use Cases"
+                , href: "https://w3c.github.io/wot-usecases/"
+                , authors: [
+                    "Michael Lagally"
+                  , "Michael McCool"
+                  , "Ryuichi Matsukura"
+                  , "Tomoaki Mizushima"
+                  ]
+                , publisher: "W3C"
+                , date: "15 October 2020"
+                , status: "Editor's Draft",
             }
         }
     };
@@ -976,8 +989,7 @@ img.wot-diagram {
         <h1>Security and Privacy Considerations</h1>
         <p>
             Security and privacy are cross-cutting issues that need to be considered
-            in all <a href="#sec-building-blocks">WoT
-                building blocks</a> and WoT implementations. This chapter
+            in all WoT building blocks and WoT implementations. This chapter
             summarizes some general issues and guidelines to help
             preserve the security and privacy of concrete WoT discovery implementations.
             For a more detailed and complete analysis of security and


### PR DESCRIPTION
- Remove section ref to WoT building blocks from Security Considerations
- Define wot-usecases reference to point to editor's draft (local reference)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/88.html" title="Last updated on Oct 21, 2020, 11:57 AM UTC (052e220)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/88/bcef86c...mmccool:052e220.html" title="Last updated on Oct 21, 2020, 11:57 AM UTC (052e220)">Diff</a>