### PR TITLE
Minor fixes in search sections of directory TD

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -183,8 +183,7 @@
           "uriVariables": {
             "query": {
               "title": "A valid JSONPath expression",
-              "type": "string",
-              "format": "iri-reference"
+              "type": "string"
             }
           },
           "forms": [
@@ -204,8 +203,7 @@
           "uriVariables": {
             "query": {
               "title": "A valid XPath expression",
-              "type": "string",
-              "format": "iri-reference"
+              "type": "string"
             }
           },
           "forms": [
@@ -225,8 +223,7 @@
           "uriVariables": {
             "query": {
               "title": "A valid SPARQL 1.1. query",
-              "type": "string",
-              "format": "iri-reference"
+              "type": "string"
             }
           },
           "forms": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -179,10 +179,10 @@
             ]
         },
         "searchJSONPath": {
-          "description": "Json Path syntactic search",
+          "description": "JSONPath syntactic search",
           "uriVariables": {
             "query": {
-              "title": "A valid Json Path expression",
+              "title": "A valid JSONPath expression",
               "type": "string",
               "format": "iri-reference"
             }


### PR DESCRIPTION
- Changed Json Path to JSONPath
- Removed iri-reference query format. I believe it was there because of a replication error. Right @AndreaCimminoArriaga?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/103.html" title="Last updated on Nov 23, 2020, 8:08 AM UTC (a3faefa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/103/bba5351...farshidtz:a3faefa.html" title="Last updated on Nov 23, 2020, 8:08 AM UTC (a3faefa)">Diff</a>