### PR TITLE
Correct combo scheme

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -39,7 +39,7 @@
             ]
         },
         "combo_sc": {
-            "scheme": "combination",
+            "scheme": "combo",
             "oneOf": [
                 "oauth2_code",
                 "oauth2_client",


### PR DESCRIPTION
Changed scheme from `combination` to `combo` to match [TD 1.1](https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme).

Related to https://github.com/w3c/wot-discovery/issues/54


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/109.html" title="Last updated on Jan 18, 2021, 2:09 PM UTC (7acfd07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/109/c944abd...farshidtz:7acfd07.html" title="Last updated on Jan 18, 2021, 2:09 PM UTC (7acfd07)">Diff</a>