### PR TITLE
Improvements to paginated TD retrieval spec

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -210,8 +210,8 @@
                 "sort_order": {
                     "description": "Sorting order",
                     "type": "string",
-                    "enum": ["ASC", "DESC"],
-                    "default": "ASC"
+                    "enum": ["asc", "desc"],
+                    "default": "asc"
                 }
             },
             "forms": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -202,12 +202,12 @@
                     "type": "boolean",
                     "default": false
                 },
-                "sortBy": {
+                "sort_by": {
                     "description": "The TD attribute used as comparator for sorting",
-                    "type": "boolean",
-                    "default": false
+                    "type": "string",
+                    "default": "id"
                 },
-                "sortOrder": {
+                "sort_order": {
                     "description": "Sorting order",
                     "type": "string",
                     "enum": ["ASC", "DESC"],
@@ -216,12 +216,20 @@
             },
             "forms": [
                 {
-                    "href": "/td{?offset,limit,count,sortBy,sortOrder}",
+                    "href": "/td{?offset,limit,count,sort_by,sort_order}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json"
+                        "contentType": "application/ld+json",
+                        "htv:headers": [
+                            {
+                                "htv:fieldName": "Link"
+                            },
+                            {
+                                "htv:fieldName": "Content-Range"
+                            }
+                        ],
                     },
                     "scopes": "readAll"
                 }

--- a/directory.td.json
+++ b/directory.td.json
@@ -17,6 +17,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search"
             ]
         },
@@ -27,6 +28,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search"
             ]
         },
@@ -38,6 +40,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search"
             ]
         },
@@ -178,6 +181,49 @@
                         "contentType": "application/td+json"
                     },
                     "scopes": "read"
+                }
+            ]
+        },
+        "retrieveTDs": {
+            "description": "Paginate and retrieve Thing Descriptions",
+            "uriVariables": {
+                "offset": {
+                    "description": "The number of TDs to skip before the collection",
+                    "type": "number",
+                    "default": 0
+                },
+                "limit": {
+                    "description": "The number of TDs in the collection",
+                    "type": "number",
+                    "default": 1 
+                },
+                "count": {
+                    "description": "Request the total number of TDs",
+                    "type": "boolean",
+                    "default": false
+                },
+                "sortBy": {
+                    "description": "The TD attribute used as comparator for sorting",
+                    "type": "boolean",
+                    "default": false
+                },
+                "sortOrder": {
+                    "description": "Sorting order",
+                    "type": "string",
+                    "enum": ["ASC", "DESC"],
+                    "default": "ASC"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/td{?offset,limit,count,sortBy,sortOrder}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/ld+json"
+                    },
+                    "scopes": "readAll"
                 }
             ]
         },

--- a/directory.td.json
+++ b/directory.td.json
@@ -231,6 +231,13 @@
                             }
                         ],
                     },
+                    "additionalResponses": [
+                        {
+                            "description": "Invalid query arguments",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
                     "scopes": "readAll"
                 }
             ]

--- a/directory.td.json
+++ b/directory.td.json
@@ -229,7 +229,7 @@
                             {
                                 "htv:fieldName": "Content-Range"
                             }
-                        ],
+                        ]
                     },
                     "additionalResponses": [
                         {

--- a/index.html
+++ b/index.html
@@ -1146,6 +1146,60 @@ img.wot-diagram {
                             [[[#directory-thing-description]]].
                         </p>
 
+
+                        <p>
+                            The following example provides a walk-through of the paginated
+                            retrieval of TDs:
+                            
+                            <aside class="example" id="example-pagination"
+                                title="Query 12 TDs with page size 10.">
+                                The client requests the list and the total count of TDs, with a `limit` of 10.
+                                <pre>
+                                    GET /td?limit=10&count=true HTTP/1.1   
+                                    Host: tdd.example.com
+                                </pre>
+
+                                The server response has a Content-Range header with the range values (0-9),
+                                total TDs (12), JSON-LD Content-Type, a `next` Link to query the remaining 2,
+                                the `canonical` Link with `etag` value set to a UUIDv4 representing the collection 
+                                state, and two other Links for `type` relations. The body is an array of 10 TDs.
+                                <pre>
+                                    HTTP/1.1 200 OK
+                                    Content-Range: TDs 0-9/12
+                                    Content-Type: application/ld+json
+                                    Link: &#x3C;https://tdd.example.com/td?offset=10&#x26;limit=10&#x3E;; rel=&#x22;next&#x22;
+                                    Link: &#x3C;https://tdd.example.com/td&#x3E;; rel=&#x22;canonical&#x22;; etag=&#x22;842542a4-abf4-4fca-a38d-ff48f6dc3088&#x22;
+                                    Link: &#x3C;http://www.w3.org/ns/td#Thing&#x3E;; rel=&#x22;type&#x22;,
+                                        &#x3C;http://www.w3.org/ns/ldp#Page&#x3E;; rel=&#x22;type&#x22;
+
+                                    [{ TD }, ...9 other TDs... ]
+                                </pre>
+
+                                The client requests the next page, either by programmatically
+                                constructing it or by using the `next` Link from the previous response.
+                                <pre>
+                                    GET /td?offset=10&limit=10 HTTP/1.1   
+                                    Host: tdd.example.com
+                                </pre>
+
+                                The server response has the remaining two TDs. The Content-Range shows the range
+                                but no total, since the count was not requested. There is no `next` Link,
+                                since this is, the last page. The client should check the `etag` value to
+                                detect if the collection has changed between the two requests.
+                                <pre>
+                                    HTTP/1.1 200 OK
+                                    Content-Range: TDs 10-12/*
+                                    Content-Type: application/ld+json
+                                    Link: &#x3C;https://tdd.example.com/td&#x3E;; rel=&#x22;canonical&#x22;; etag=&#x22;842542a4-abf4-4fca-a38d-ff48f6dc3088&#x22;
+                                    Link: &#x3C;http://www.w3.org/ns/td#Thing&#x3E;; rel=&#x22;type&#x22;,
+                                        &#x3C;http://www.w3.org/ns/ldp#Page&#x3E;; rel=&#x22;type&#x22;
+    
+                                    [{ TD }, { TD }]
+                                </pre>
+
+                            </aside>  
+                        </p>
+
                         <p class="ednote" title="Status codes">
                             It may be appropriate to use 206 (Partial Content) for paginated 
                             responses and 416 (Range Not Satisfiable) for out of

--- a/index.html
+++ b/index.html
@@ -95,6 +95,18 @@
                 , date: "7 December 2020"
                 , status: "DRAFT",
             },
+            "LDP-Paging" : {
+                  title: "Linked Data Platform Paging"
+                , href: "https://www.w3.org/TR/ldp-paging/"
+                , authors: [
+                    "Steve Speicher"
+                  , "John Arwe"
+                  , "Ashok Malhotra"
+                  ]
+                , publisher: "W3C"
+                , date: "30 June 2015"
+                , status: "Note",
+            },
             "wot-usecases" : {
                   title: "Web of Things (WoT): Use Cases"
                 , href: "https://w3c.github.io/wot-usecases/"
@@ -994,69 +1006,112 @@ img.wot-diagram {
                     <section id="exploration-directory-api-registration-listing" class="normative">
                         <h4>Listing</h4>
                         <p>
-                            <span class="rfc2119-assertion" id="tdd-reg-list">
-                                The list of TDs MUST be retrieved from the directory using an
-                                HTTP `GET` request to the root endpoint of the registration API.
-                            </span>
+                            The listing endpoint provides a way to query the collection of TD objects
+                            from the directory. The Search API may be used to retrieve <a>Partial TD</a>s
+                            or TD fragments; see [[[#exploration-directory-api-search]]].
+                            
                         </p>
-                        <p> <!-- paginated listing -->
+                        <p> 
                             <span class="rfc2119-assertion" id="tdd-reg-list-resp-pagination">
                                 The default response MUST be paginated to limit the
                                 set of enclosed TDs in a single response.
                             </span>
-                            The pagination must be based on the following rules:
+                            The paginated response is a subset of the TD collection.
+                            <span class="rfc2119-assertion" id="tdd-reg-list-resp-alternative">
+                                A server which supports alternative mechanisms (such as streaming)
+                                MAY rely on server-driven content negotiation and respond accordingly.
+                            </span>
+                        </p>
+                        <p>
+
+                            The paginated response is inspired by [[?LDP-Paging]].
+                            It must be based on the following rules:
                             <ul>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination">
+                                        The paginated TDs MUST be retrieved from the directory using an
+                                        HTTP `GET` request.
+                                    </span>
+                                </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-resp">
                                         A successful response MUST have 200 (OK) status, contain `application/ld+json`
-                                        Content-Type header, and a set of TDs in a collection object in body.
+                                        Content-Type header, and an array of TDs in body.
                                     </span>
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-envelop">
-                                        The TDs MUST be complete TD objects inside an array
-                                        called `items` enclosed in the collection object. 
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-limit">
+                                        The total of TDs in each response MUST NOT be larger than the
+                                        requested number in `limit` query parameter.
                                     </span>
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total">
-                                        The number of TDs in each response MUST match the requested number.
-                                    </span>
-                                    The server should enforce an appropriate or configurable maximum number
+                                    The server should enforce an appropriate or configurable maximum limit
                                     of TDs per request to manage the processing load on the server side.
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total-default">
-                                        When a total number is not given in a request, it MUST default to 1.
+                                        When the `limit` query parameter is not set in a request, it MUST default to 1.
                                     </span>
                                     This is to avoid unintended traffic and load on memory-constrained clients.
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-id">
+                                    <!-- <span class="rfc2119-assertion" id="tdd-reg-list-pagination-id">
                                         The collection object MUST contains an `id` attribute
                                         pointing to the current page (self link).
+                                    </span> -->
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-nextlink">
+                                        The response header MUST contain a Link header with
+                                        `next` relation type for querying the remaining set of TDs, when present.
                                     </span>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-links">
-                                        The collection object MUST contains a `nextLink` attribute
-                                        for querying the next page, when present.
-                                    </span>
-                                    The links may be relative to directory API base URL, or be absolute URLs.
-                                    These links may include additional arguments for ordering or session keys.
+                                    For example, 
+                                    `Link: <&#47;td?offset=10&limit=10>; rel="next"` 
+                                    describes a link to retrieve up to 10 remaining TDs.
+                                    The next link may be absolute or relative to directory API's base URL.
+                                    This link should include additional arguments for ordering or session keys.
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total">
-                                        When requested, the collection object MUST contain a `total` attribute 
-                                        equal to total number of TDs within the directory.
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-canonicallink">
+                                        The response header MUST contain a Link header with `canonical` relation type
+                                        pointing to the collection and include an `etag` parameter to represent
+                                        the current state of the collection.
                                     </span>
+                                    For example,
+                                    `Link: <&#47;td>; rel="canonical"; etag="v1"`
+                                    contains the link to the collection and a `etag` set to "v1".
+                                    The canonical link may be absolute or relative to directory API's base URL.
+                                    The `etag` value could be a version, timestamp, or UUIDv4, reset whenever the TD
+                                    collection changes i.e. after creation, deletion, update of TDs.
                                 </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-contentrange">
+                                        The response header MUST contain a Content-Range header indicating the
+                                        range of TDs in response body and if requested, the total number of TDs
+                                        present in the collection.
+                                    </span>
+                                    For example,
+                                    `Content-Range: TDs 0-9/*` indicates that the page contains the first 10 TDs
+                                    and an unknown total. Comparatively, 
+                                    `Content-Range: TDs 0-9/35` also indicates that the collection contains 35 TDs
+                                    in total. 
+                                    
+                                    The total is useful for parallel paginated requests instead of sequential
+                                    queries and next link traversals. In practice, a client which intends to know the
+                                    total before retrieving any TDs may request the total with a limit of 0.
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-count">
+                                        The total number of TDs in a collection MUST be requested by setting
+                                        `count` query parameter to `true`.
+                                    </span>
+                                    
+                                </li>
+                                
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order-default">
                                         By default, the collection MUST be sorted alphanumerically 
                                         by the unique identifiers of TDs.
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order">
-                                        The server MAY support sorting by other TD attributes (e.g. `created` field) and 
-                                        different sorting orders (i.e. ascendingly/descendingly).
+                                        The server MAY support sorting by other TD attributes
+                                        (e.g. `created` field) and different sorting orders 
+                                        (i.e. `asc` or `desc` for ascending and descending ordering).
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order-unsupported">
                                         If the server does not support a given sorting argument, 
@@ -1066,21 +1121,10 @@ img.wot-diagram {
                             </ul>
                         </p>
 
-                        <!-- <p>    
-                            The paginated list operation is specified as `listTD` property in 
+                        <p>    
+                            The paginated list operation is specified as `retrieveTDs` property in 
                             [[[#directory-thing-description]]].
-                        </p> -->
-                        <p class="ednote" title="Registration listing query arguments">
-                            Need to specify and describe the query arguments to paginate
-                            and get total. The paginated list operation should be specified as `listTD` 
-                            property in [[[#directory-thing-description]]].
                         </p>
-                        
-
-                        <span class="rfc2119-assertion" id="tdd-reg-list-resp-alternative">
-                            A server which supports alternative mechanisms (such as streaming)
-                            MAY rely on server-driven content negotiation and respond accordingly.
-                        </span>
 
                         <p>
                             Error responses:  
@@ -1094,32 +1138,6 @@ img.wot-diagram {
                             </ul>
                         </p>
 
-                        The following is an example paginated list response with total:
-                        <aside class="example" id="example-td-registration-info" title="Example response for a paginated list with total">
-                            <pre>
-                                {
-                                    "@context": "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld",
-                                    "id": "/td?offset=0&limit=10",
-                                    "type": "Collection",
-                                    "items": [ 
-                                        {
-                                            "@context": "https://www.w3.org/2019/wot/td/v1",
-                                            "id": "urn:example:simple-td",
-                                            "title": "Simple TD",
-                                            "security": "basic_sc",
-                                            "securityDefinitions": {
-                                                "basic_sc": {
-                                                    "scheme": "basic"
-                                                }
-                                            }
-                                        }, 
-                                        ...
-                                    ],
-                                    "total": 350,
-                                    "nextLink": "/td?offset=10&limit=10"
-                                }
-                            </pre>                  
-                        </aside>
                     </section>
 
                     <section id="validation" class="normative">

--- a/index.html
+++ b/index.html
@@ -95,18 +95,6 @@
                 , date: "7 December 2020"
                 , status: "DRAFT",
             },
-            "LDP-Paging" : {
-                  title: "Linked Data Platform Paging"
-                , href: "https://www.w3.org/TR/ldp-paging/"
-                , authors: [
-                    "Steve Speicher"
-                  , "John Arwe"
-                  , "Ashok Malhotra"
-                  ]
-                , publisher: "W3C"
-                , date: "30 June 2015"
-                , status: "Note",
-            },
             "wot-usecases" : {
                   title: "Web of Things (WoT): Use Cases"
                 , href: "https://w3c.github.io/wot-usecases/"
@@ -1024,8 +1012,9 @@ img.wot-diagram {
                         </p>
                         <p>
 
-                            The paginated response is inspired by [[?LDP-Paging]].
-                            It must be based on the following rules:
+                            The paginated mechanism is based on [[?LDP-Paging]], utilizing Link [[RFC8288]] 
+                            and Content-Range [[RFC7233]] headers in responses.
+                            The pagination must be based on the following rules:
                             <ul>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination">
@@ -1062,11 +1051,14 @@ img.wot-diagram {
                                         The response header MUST contain a Link header with
                                         `next` relation type for querying the remaining set of TDs, when present.
                                     </span>
-                                    For example, 
-                                    `Link: <&#47;td?offset=10&limit=10>; rel="next"` 
-                                    describes a link to retrieve up to 10 remaining TDs.
+                                    [[[#example-header-next-link]]] describes a link to retrieve up to 10 remaining TDs.
                                     The next link may be absolute or relative to directory API's base URL.
                                     This link should include additional arguments for ordering or session keys.
+                                    <aside class="example" id="example-header-next-link" title="Link header with the relative next link">
+                                        <pre>
+                                            Link: <&#47;td?offset=10&limit=10>; rel="next"
+                                        </pre>
+                                    </aside>
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-canonicallink">
@@ -1074,12 +1066,30 @@ img.wot-diagram {
                                         pointing to the collection and include an `etag` parameter to represent
                                         the current state of the collection.
                                     </span>
-                                    For example,
-                                    `Link: <&#47;td>; rel="canonical"; etag="v1"`
-                                    contains the link to the collection and a `etag` set to "v1".
+                                    [[[#example-header-canonical-link]]] contains the link to the collection and 
+                                    a `etag` set to "v1".
                                     The canonical link may be absolute or relative to directory API's base URL.
                                     The `etag` value could be a version, timestamp, or UUIDv4, reset whenever the TD
                                     collection changes i.e. after creation, deletion, update of TDs.
+                                    <aside class="example" id="example-header-canonical-link" title="Link header with the relative canonical link">
+                                        <pre>
+                                            Link: <&#47;td>; rel="canonical"; etag="v1"
+                                        </pre>
+                                    </aside>
+                                </li>
+                                <li>
+                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-typelinks">
+                                        The response header MAY contain the two Link headers with 
+                                        `type` relation types and URI references set to 
+                                        `http://www.w3.org/ns/td#Thing` and `http://www.w3.org/ns/ldp#Page`
+                                        to classify the represented resource.
+                                    </span>
+                                    [[[#example-header-type-links]]] shows the Link headers with two `type` links.
+                                    <aside class="example" id="example-header-type-links" title="Link header with type links">
+                                        <pre>
+                                            Link: &#x3C;http://www.w3.org/ns/td#Thing&#x3E;; rel=&#x22;type&#x22;, &#x3C;http://www.w3.org/ns/ldp#Page&#x3E;; rel=&#x22;type&#x22;
+                                        </pre>
+                                    </aside>                                    
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-reg-list-pagination-header-contentrange">
@@ -1087,11 +1097,10 @@ img.wot-diagram {
                                         range of TDs in response body and if requested, the total number of TDs
                                         present in the collection.
                                     </span>
-                                    For example,
-                                    `Content-Range: TDs 0-9/*` indicates that the page contains the first 10 TDs
-                                    and an unknown total. Comparatively, 
-                                    `Content-Range: TDs 0-9/35` also indicates that the collection contains 35 TDs
-                                    in total. 
+                                    [[[#example-header-content-range-without-size]]] indicates that
+                                    the page contains the first 10 TDs and an unknown total. 
+                                    Comparatively, [[[#example-header-content-range]]]
+                                    also indicates that the collection contains 35 TDs in total. 
                                     
                                     The total is useful for parallel paginated requests instead of sequential
                                     queries and next link traversals. In practice, a client which intends to know the
@@ -1100,7 +1109,18 @@ img.wot-diagram {
                                         The total number of TDs in a collection MUST be requested by setting
                                         `count` query parameter to `true`.
                                     </span>
-                                    
+                                    <aside class="example" id="example-header-content-range-without-size" 
+                                        title="Content-Range header for range 0-9 and unknown size">
+                                        <pre>
+                                            Content-Range: TDs 0-9/*                                        
+                                        </pre>
+                                    </aside>    
+                                    <aside class="example" id="example-header-content-range"
+                                        title="Content-Range header for range 0-9 and size 35">
+                                        <pre>
+                                            Content-Range: TDs 0-9/35                                       
+                                        </pre>
+                                    </aside> 
                                 </li>
                                 
                                 <li>
@@ -1126,9 +1146,22 @@ img.wot-diagram {
                             [[[#directory-thing-description]]].
                         </p>
 
+                        <p class="ednote" title="Status codes">
+                            It may be appropriate to use 206 (Partial Content) for paginated 
+                            responses and 416 (Range Not Satisfiable) for out of
+                            range requests. These are suggested by 
+                            <a href=https://tools.ietf.org/html/rfc7233#section-4>RFC7233 Range Requests</a>
+                            in response to range requests.
+                            <br/>
+                            The current specs mandates 200 and 400 respectively.
+                        </p>
+
                         <p>
                             Error responses:  
                             <ul>
+                                <li>
+                                    400 (Bad Request): Invalid query arguments.
+                                </li>
                                 <li>
                                     401 (Unauthorized): No authentication.
                                 </li>

--- a/index.html
+++ b/index.html
@@ -1153,16 +1153,12 @@ img.wot-diagram {
                             
                             <aside class="example" id="example-pagination"
                                 title="Query 12 TDs with page size 10.">
-                                The client requests the list and the total count of TDs, with a `limit` of 10.
+                                The client requests the list and the total count of TDs, with a `limit` of 10:
                                 <pre>
                                     GET /td?limit=10&count=true HTTP/1.1   
                                     Host: tdd.example.com
                                 </pre>
-
-                                The server response has a Content-Range header with the range values (0-9),
-                                total TDs (12), JSON-LD Content-Type, a `next` Link to query the remaining 2,
-                                the `canonical` Link with `etag` value set to a UUIDv4 representing the collection 
-                                state, and two other Links for `type` relations. The body is an array of 10 TDs.
+                                Response:
                                 <pre>
                                     HTTP/1.1 200 OK
                                     Content-Range: TDs 0-9/12
@@ -1174,18 +1170,23 @@ img.wot-diagram {
 
                                     [{ TD }, ...9 other TDs... ]
                                 </pre>
-
+                                The server response has a Content-Range header with range values and
+                                total count of TDs. The Content-Type indicates that the response is JSON-LD. 
+                                There are several Links: `next` Link to query the remaining TDs,
+                                `canonical` Link pointing to the collection endpoint with `etag` value set
+                                to a UUID representing the current state of the collection
+                                state, and two other Links for `type` relations. 
+                                The body is an array of 10 TDs.
+                                
+                                <br><br>
                                 The client requests the next page, either by programmatically
-                                constructing it or by using the `next` Link from the previous response.
+                                constructing the URL or by using the `next` Link from the previous response:
                                 <pre>
                                     GET /td?offset=10&limit=10 HTTP/1.1   
                                     Host: tdd.example.com
                                 </pre>
 
-                                The server response has the remaining two TDs. The Content-Range shows the range
-                                but no total, since the count was not requested. There is no `next` Link,
-                                since this is, the last page. The client should check the `etag` value to
-                                detect if the collection has changed between the two requests.
+                                Response:
                                 <pre>
                                     HTTP/1.1 200 OK
                                     Content-Range: TDs 10-12/*
@@ -1196,7 +1197,11 @@ img.wot-diagram {
     
                                     [{ TD }, { TD }]
                                 </pre>
-
+                                The server response has the remaining two TDs. The Content-Range shows the range
+                                but no total, since the count was not requested. There is no `next` Link,
+                                because this is the last page. The client should check the `etag` value to
+                                detect if the collection has changed between the two requests and decide
+                                whether it should query from the beginning.
                             </aside>  
                         </p>
 

--- a/index.html
+++ b/index.html
@@ -1189,7 +1189,7 @@ img.wot-diagram {
                                 Response:
                                 <pre>
                                     HTTP/1.1 200 OK
-                                    Content-Range: TDs 10-12/*
+                                    Content-Range: TDs 10-11/*
                                     Content-Type: application/ld+json
                                     Link: &#x3C;https://tdd.example.com/td&#x3E;; rel=&#x22;canonical&#x22;; etag=&#x22;842542a4-abf4-4fca-a38d-ff48f6dc3088&#x22;
                                     Link: &#x3C;http://www.w3.org/ns/td#Thing&#x3E;; rel=&#x22;type&#x22;,


### PR DESCRIPTION
- [x] Specify query arguments based on the original proposal
- [x] Specify headers and modify to match https://www.w3.org/TR/ldp-paging/ as suggested in https://github.com/w3c/wot-discovery/issues/16#issuecomment-792663791
- [x] Change spec document to match header-based approach


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/130.html" title="Last updated on Mar 23, 2021, 10:17 AM UTC (d78b6ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/130/e6f18dd...farshidtz:d78b6ca.html" title="Last updated on Mar 23, 2021, 10:17 AM UTC (d78b6ca)">Diff</a>