### PR TITLE
Validation error example

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@ img.wot-diagram {
                     The HTTP API responses must use appropriate status codes described in 
                     this section for success and error responses.
                     <span class="rfc2119-assertion" id="tdd-http-errors"> 
-                        The HTTP API SHOULD use the Problem Details [[RFC7807]] format to carry
+                        The HTTP API MUST use the Problem Details [[RFC7807]] format to carry
                         error details in HTTP client error (4xx) and server error (5xx) responses.
                     </span>
                     This enables both machines and humans to know the high-level error class
@@ -1133,11 +1133,11 @@ img.wot-diagram {
                             </span>
     
                             <span class="rfc2119-assertion" id="td-validation-response">
-                                The validation error SHOULD be described as Problem Details [[RFC7807]]
-                                and extended with a `validationErrors` array of objects
-                                with `field` and `description` fields to represent the error in a
-                                machine-readable way. 
+                                The validation error MUST be described as Problem Details [[RFC7807]]
+                                with an extension field called `validationErrors`, set to an array of objects
+                                with `field` and `description` fields.
                             </span>
+                            This is necessary to represent the error in a machine-readable way. 
                         </p>
                         
                         [[[#example-validation-error]]] is an example error response with two validation errors.

--- a/index.html
+++ b/index.html
@@ -1132,12 +1132,10 @@ img.wot-diagram {
                                 with necessary details to identify and resolve the errors.
                             </span>
     
-                            Validation errors are described as Problem Details [[RFC7807]], similar to all other
-                            response errors.
                             <span class="rfc2119-assertion" id="td-validation-response">
                                 The validation error SHOULD be described as Problem Details [[RFC7807]]
-                                and contain an `invalid-params` field set to an array of objects
-                                with `name` and `reason` fields to represent the error in a
+                                and extended with a `validationErrors` array of objects
+                                with `field` and `description` fields to represent the error in a
                                 machine-readable way. 
                             </span>
                         </p>
@@ -1146,25 +1144,26 @@ img.wot-diagram {
                         <aside class="example" id="example-validation-error" title="Example validation error response">
                             <pre>
                                 {
-                                    "title": "Invalid Registration",
+                                    "title": "Bad Request",
                                     "status": 400,
-                                    "detail": "Validation against JSON Schema detected one or more errors",
-                                    "instance": "/error/123e4567-e89b-12d3-a456-426655440000",
-                                    "invalid-params": [
+                                    "detail": "The input did not pass the JSON Schema validation",
+                                    "instance": "/errors/30585584-cce2-4d04-8079-67b33ffdafbc",
+                                    "validationErrors": [
                                         {
-                                            "name": "security",
-                                            "reason": "security is required"
+                                            "field": "(root)",
+                                            "description": "security is required"
                                         },
                                         {
-                                            "name": "properties.lightInformation.properties.state.properties.lastupdated.type",
-                                            "reason": "properties.lightInformation.properties.state.properties.lastupdated.type must be one of the following: \"boolean\", \"integer\", \"number\", \"string\", \"object\", \"array\", \"null\""
+                                            "field": "properties.status.forms.0.href",
+                                            "description": "Invalid type. Expected: string, given: integer"
                                         }
                                     ]
-                                }                         
+                                }                      
                             </pre>
                             <p class="ednote" title="Validation error type">
-                                This example skips the type field 
-                                due to the lack of specific error types. See notes in [[[#exploration-directory-api]]].
+                                This example skips the `type` field 
+                                due to the current lack of specific error types. 
+                                See notes in [[[#exploration-directory-api]]].
                             </p>
                         </aside>
                         

--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@ img.wot-diagram {
                     The HTTP API responses must use appropriate status codes described in 
                     this section for success and error responses.
                     <span class="rfc2119-assertion" id="tdd-http-errors"> 
-                        The HTTP API MUST use the Problem Details [[RFC7807]] format to carry
+                        The HTTP API SHOULD use the Problem Details [[RFC7807]] format to carry
                         error details in HTTP client error (4xx) and server error (5xx) responses.
                     </span>
                     This enables both machines and humans to know the high-level error class
@@ -1115,25 +1115,61 @@ img.wot-diagram {
 
                     <section id="validation" class="normative">
                         <h4>Validation</h4>
-                        <span class="rfc2119-assertion" id="td-validation-syntactic">
-                            The syntactic validation of TD objects before storage is RECOMMENDED to
-                            prevent common erroneous submissions.
-                        </span>
-                        <span class="rfc2119-assertion" id="td-validation-jsonschema">
-                            The server MAY use
-                            <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
-                            to validate standard TD vocabulary, or a more comprehensive JSON Schema to also validate extensions.
-
-                        </span>
-                        <span class="rfc2119-assertion" id="td-validation-result">
-                            If the server fails to validate the TD object, it MUST inform the client
-                            with necessary details to identify and resolve the errors.
-                        </span>
-
-                        <p class="ednote" title="Validation Example">
-                            It would be nice to include an example validation result in
-                            the uniform error format (i.e. RFC7807 Problem Details).
+                        <p>
+                           <span class="rfc2119-assertion" id="td-validation-syntactic">
+                                The syntactic validation of TD objects before storage is RECOMMENDED to
+                                prevent common erroneous submissions.
+                            </span>
+                            <span class="rfc2119-assertion" id="td-validation-jsonschema">
+                                The server MAY use
+                                <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
+                                to validate standard TD vocabulary, or a more comprehensive JSON Schema to also validate extensions.
+                            </span>
                         </p>
+                        <p>
+                            <span class="rfc2119-assertion" id="td-validation-result">
+                                If the server fails to validate the TD object, it MUST inform the client
+                                with necessary details to identify and resolve the errors.
+                            </span>
+    
+                            Validation errors are described as Problem Details [[RFC7807]], similar to all other
+                            response errors.
+                            <span class="rfc2119-assertion" id="td-validation-response">
+                                The validation error SHOULD be described as Problem Details [[RFC7807]]
+                                and contain an `invalid-params` field set to an array of objects
+                                with `name` and `reason` fields to represent the error in a
+                                machine-readable way. 
+                            </span>
+                        </p>
+                        
+                        [[[#example-validation-error]]] is an example error response with two validation errors.
+                        <aside class="example" id="example-validation-error" title="Example validation error response">
+                            <pre>
+                                {
+                                    "title": "Invalid Registration",
+                                    "status": 400,
+                                    "detail": "Validation against JSON Schema detected one or more errors",
+                                    "instance": "/error/123e4567-e89b-12d3-a456-426655440000",
+                                    "invalid-params": [
+                                        {
+                                            "name": "security",
+                                            "reason": "security is required"
+                                        },
+                                        {
+                                            "name": "properties.lightInformation.properties.state.properties.lastupdated.type",
+                                            "reason": "properties.lightInformation.properties.state.properties.lastupdated.type must be one of the following: \"boolean\", \"integer\", \"number\", \"string\", \"object\", \"array\", \"null\""
+                                        }
+                                    ]
+                                }                         
+                            </pre>
+                            <p class="ednote" title="Validation error type">
+                                This example skips the type field 
+                                due to the lack of specific error types. See notes in [[[#exploration-directory-api]]].
+                            </p>
+                        </aside>
+                        
+                        
+
                         <div class="issue" data-number="99"></div>
                     </section>
 


### PR DESCRIPTION
This PR add a validation error example.

~~Moreover, it makes the use of [RFC7807 Problem Details](https://tools.ietf.org/html/rfc7807) recommended, instead of mandatory.~~


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/136.html" title="Last updated on Mar 23, 2021, 3:33 PM UTC (e8022ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/136/329756e...farshidtz:e8022ef.html" title="Last updated on Mar 23, 2021, 3:33 PM UTC (e8022ef)">Diff</a>