### PR TITLE
Listing with chunked transfer

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -228,6 +228,21 @@
                 }
             ]
         },
+        "retrieveTDs": {
+            "description": "Retrieve all Thing Descriptions",
+            "forms": [
+                {
+                    "href": "/td",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/ld+json",
+                    },
+                    "scopes": "readAll"
+                }
+            ]
+        },
         "searchJSONPath": {
             "description": "JSONPath syntactic search",
             "uriVariables": {

--- a/index.html
+++ b/index.html
@@ -1017,11 +1017,11 @@ img.wot-diagram {
                             Memory-constrained applications which require the full list
                             should consider processing the received data incrementally.
 
-                            <p class="ednote" title="HTTP/2 chunking">
-                                This should be tested before turned into an assertion:<br>
-                                Chunked transfer encoding is not supported in HTTP/2.
-                                HTTP/2 servers SHOULD respond the data incrementally using frames.
-                            </p>
+                            Chunked transfer encoding is not supported in HTTP/2.
+                            <span class="rfc2119-assertion" id="tdd-reg-list-http2">
+                                HTTP/2 servers SHOULD respond the data incrementally using 
+                                <a href="https://tools.ietf.org/html/rfc7540#section-4">HTTP Frames</a> [[RFC7540]].
+                            </span>
                         </p>
 
                         <p>    

--- a/index.html
+++ b/index.html
@@ -985,93 +985,49 @@ img.wot-diagram {
                     <section id="exploration-directory-api-registration-listing" class="normative">
                         <h4>Listing</h4>
                         <p>
-                            <span class="rfc2119-assertion" id="tdd-reg-list">
-                                The list of TDs MUST be retrieved from the directory using an
-                                HTTP `GET` request to the root endpoint of the registration API.
-                            </span>
-                        </p>
-                        <p> <!-- paginated listing -->
-                            <span class="rfc2119-assertion" id="tdd-reg-list-resp-pagination">
-                                The default response MUST be paginated to limit the
-                                set of enclosed TDs in a single response.
-                            </span>
-                            The pagination must be based on the following rules:
-                            <ul>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-resp">
-                                        A successful response MUST have 200 (OK) status, contain `application/ld+json`
-                                        Content-Type header, and a set of TDs in a collection object in body.
-                                    </span>
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-envelop">
-                                        The TDs MUST be complete TD objects inside an array
-                                        called `items` enclosed in the collection object. 
-                                    </span>
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total">
-                                        The number of TDs in each response MUST match the requested number.
-                                    </span>
-                                    The server should enforce an appropriate or configurable maximum number
-                                    of TDs per request to manage the processing load on the server side.
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total-default">
-                                        When a total number is not given in a request, it MUST default to 1.
-                                    </span>
-                                    This is to avoid unintended traffic and load on memory-constrained clients.
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-id">
-                                        The collection object MUST contains an `id` attribute
-                                        pointing to the current page (self link).
-                                    </span>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-links">
-                                        The collection object MUST contains a `nextLink` attribute
-                                        for querying the next page, when present.
-                                    </span>
-                                    The links may be relative to directory API base URL, or be absolute URLs.
-                                    These links may include additional arguments for ordering or session keys.
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-total">
-                                        When requested, the collection object MUST contain a `total` attribute 
-                                        equal to total number of TDs within the directory.
-                                    </span>
-                                </li>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order-default">
-                                        By default, the collection MUST be sorted alphanumerically 
-                                        by the unique identifiers of TDs.
-                                    </span>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order">
-                                        The server MAY support sorting by other TD attributes (e.g. `created` field) and 
-                                        different sorting orders (i.e. ascendingly/descendingly).
-                                    </span>
-                                    <span class="rfc2119-assertion" id="tdd-reg-list-pagination-order-unsupported">
-                                        If the server does not support a given sorting argument, 
-                                        it MUST reject the request with 501 (Not Implemented) status.
-                                    </span>
-                                </li>
-                            </ul>
-                        </p>
-
-                        <!-- <p>    
-                            The paginated list operation is specified as `listTD` property in 
-                            [[[#directory-thing-description]]].
-                        </p> -->
-                        <p class="ednote" title="Registration listing query arguments">
-                            Need to specify and describe the query arguments to paginate
-                            and get total. The paginated list operation should be specified as `listTD` 
-                            property in [[[#directory-thing-description]]].
+                            The listing endpoint provides a way to query the collection of TD objects
+                            from the directory. The Search API may be used to retrieve <a>Partial TD</a>s
+                            or TD fragments; see [[[#exploration-directory-api-search]]].
                         </p>
                         
+                            
+                        <p>
+                            <span class="rfc2119-assertion" id="tdd-reg-list-method">
+                                The list of TDs MUST be retrieved from the directory using an
+                                HTTP `GET` request.
+                            </span>
+                        
+                            <span class="rfc2119-assertion" id="tdd-reg-list-resp">
+                                A successful response MUST have 200 (OK) status, contain `application/ld+json`
+                                Content-Type header, and an array of TDs in body.
+                            </span>
+                        </p>
 
-                        <span class="rfc2119-assertion" id="tdd-reg-list-resp-alternative">
-                            A server which supports alternative mechanisms (such as streaming)
-                            MAY rely on server-driven content negotiation and respond accordingly.
-                        </span>
+                        <p>
+                            Serializing and returning the full list of TDs may be burdensome to servers.
+                            As such, servers should serialize incrementally and utilize protocol-specific
+                            mechanisms to respond in chunks. 
+                            <span class="rfc2119-assertion" id="tdd-reg-list-http11">
+                                HTTP/1.1 servers SHOULD perform chunked 
+                                <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">Transfer-Encoding</a> [[RFC7230]]
+                                to respond the data incrementally.
+                            </span>
+                            Most HTTP/1.1 clients automatically process the data received with 
+                            chunked transfer encoding.
+                            Memory-constrained applications which require the full list
+                            should consider processing the received data incrementally.
+
+                            <p class="ednote" title="HTTP/2 chunking">
+                                This should be tested before turned into an assertion:<br>
+                                Chunked transfer encoding is not supported in HTTP/2.
+                                HTTP/2 servers SHOULD respond the data incrementally using frames.
+                            </p>
+                        </p>
+
+                        <p>    
+                            The paginated list operation is specified as `retrieveTDs` property in 
+                            [[[#directory-thing-description]]].
+                        </p>
 
                         <p>
                             Error responses:  
@@ -1085,32 +1041,7 @@ img.wot-diagram {
                             </ul>
                         </p>
 
-                        The following is an example paginated list response with total:
-                        <aside class="example" id="example-td-registration-info" title="Example response for a paginated list with total">
-                            <pre>
-                                {
-                                    "@context": "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld",
-                                    "id": "/td?offset=0&limit=10",
-                                    "type": "Collection",
-                                    "items": [ 
-                                        {
-                                            "@context": "https://www.w3.org/2019/wot/td/v1",
-                                            "id": "urn:example:simple-td",
-                                            "title": "Simple TD",
-                                            "security": "basic_sc",
-                                            "securityDefinitions": {
-                                                "basic_sc": {
-                                                    "scheme": "basic"
-                                                }
-                                            }
-                                        }, 
-                                        ...
-                                    ],
-                                    "total": 350,
-                                    "nextLink": "/td?offset=10&limit=10"
-                                }
-                            </pre>                  
-                        </aside>
+                        
                     </section>
 
                     <section id="validation" class="normative">

--- a/index.html
+++ b/index.html
@@ -999,7 +999,7 @@ img.wot-diagram {
                         
                             <span class="rfc2119-assertion" id="tdd-reg-list-resp">
                                 A successful response MUST have 200 (OK) status, contain `application/ld+json`
-                                Content-Type header, and an array of TDs in body.
+                                Content-Type header, and an array of TDs in the body.
                             </span>
                         </p>
 


### PR DESCRIPTION
This proposal simplifies the listing API by suggesting streaming instead of pagination.

Most HTTP servers and clients support this internally. Moreover, this makes the discovery spec much simpler as there is no need to specify query arguments for ranges, sorting, and headers. The proposal #130 was getting out of hand with several substandard requirements.

Chunked transfer encoding can be mapped to CoAP: https://tools.ietf.org/html/draft-castellani-core-http-coap-mapping-00#appendix-A.2

Please also refer to the original discussion in https://github.com/w3c/wot-discovery/issues/16.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/145.html" title="Last updated on Mar 26, 2021, 11:46 AM UTC (170ddf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/145/329756e...farshidtz:170ddf5.html" title="Last updated on Mar 26, 2021, 11:46 AM UTC (170ddf5)">Diff</a>