### PR TITLE
Combine properties into a single things property

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -199,53 +199,45 @@
         }
     },
     "properties": {
-        "retrieveTD": {
-            "description": "Retrieve a Thing Description",
+        "things": {
+           "@type": "ThingListProperty",
+            "description": "Collection of Thing Descriptions in the directory",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/td/{id}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/td+json"
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "TD with the given id not found",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 404
-                        }
-                    ],
-                    "scopes": "read"
-                }
-            ]
-        },
-        "retrieveTDs": {
-            "description": "Retrieve all Thing Descriptions",
-            "uriVariables": {
+                },
+                "jsonpath": {
+                    "@type": "JSONPathExpression",
+                    "title": "A valid JSONPath expression",
+                    "type": "string"
+                },
+                "xpath": {
+                    "@type": "XPathExpression",
+                    "title": "A valid XPath expression",
+                    "type": "string"
+                },
                 "offset": {
+                    "@type": "PageOffset",
                     "title": "Number of TDs to skip before the page",
                     "type": "number",
                     "default": 0
                 },
                 "limit": {
+                    "@type": "PageLimit",
                     "title": "Number of TDs in a page",
                     "type": "number"
                 },
                 "sort_by": {
+                    "@type": "SortAttribute",
                     "title": "Comparator TD attribute for collection sorting",
                     "type": "string",
                     "default": "id"
                 },
                 "sort_order": {
+                    "@type": "SortOrder",
                     "title": "Sorting order",
                     "type": "string",
                     "enum": ["asc", "desc"],
@@ -254,17 +246,17 @@
             },
             "forms": [
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json"
+                        "contentType": "application/td+json"
                     },
                     "scopes": "readAll"
                 },
                 {
-                    "href": "/td{?offset,limit,sort_by,sort_order}",
+                    "href": "/things{?offset,limit,sort_by,sort_order}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -284,79 +276,30 @@
                         }
                     ],
                     "scopes": "readAll"
-                }
-            ]
-        },
-        "searchJSONPath": {
-            "description": "JSONPath syntactic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid JSONPath expression",
-                    "type": "string"
-                }
-            },
-            "forms": [
+                },
                 {
-                    "href": "/search/jsonpath?query={query}",
+                    "href": "/things/{id}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "TD with the given id not found",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 404
+                        }
+                    ],
+                    "scopes": "read"
+                },
+                {
+                    "href": "/things?jsonpath={jsonpath}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "contentType": "application/json",
-                        "htv:statusCodeValue": 200
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "JSONPath expression not provided or contains syntax errors",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "search"
-                }
-            ]
-        },
-        "searchXPath": {
-            "description": "XPath syntactic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid XPath expression",
-                    "type": "string"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/search/xpath?query={query}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "contentType": "application/json",
-                        "htv:statusCodeValue": 200
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "JSONPath expression not provided or contains syntax errors",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "search"
-                }
-            ]
-        },
-        "searchSPARQL": {
-            "description": "SPARQL semantic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid SPARQL 1.1. query",
-                    "type": "string"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/search/sparql?query={query}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
                         "htv:statusCodeValue": 200
                     },
                     "additionalResponses": [
@@ -369,8 +312,8 @@
                     "scopes": "search"
                 },
                 {
-                    "href": "/search/sparql",
-                    "htv:methodName": "POST",
+                    "href": "/things?xpath={xpath}",
+                    "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "contentType": "application/json",
@@ -378,7 +321,72 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "JSONPath expression not provided or contains syntax errors",
+                            "description": "XPath expression not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                }
+            ]
+        },
+        "sparql": {
+            "@type": "SPARQLProperty",
+            "description": "Endpoint for querying the directory with SPARQL",
+            "uriVariables": {
+                "query": {
+                    "@type": "SPARQLQuery",
+                    "title": "A valid SPARQL 1.1. query",
+                    "type": "string"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/sparql?query={query}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                },
+                {
+                    "href": "/sparql",
+                    "htv:methodName": "POST",
+                    "contentType:": "application/x-www-form-urlencoded",
+                    "response": {
+                        "description": "Success response",
+                        "contentType": "application/json",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                },
+                {
+                    "href": "/sparql",
+                    "htv:methodName": "POST",
+                    "contentType:": "application/sparql-query",
+                    "response": {
+                        "description": "Success response",
+                        "contentType": "application/json",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }


### PR DESCRIPTION
This PR proposes combining the current `retrieveTD`, `retrieveTDs`, `searchJSONPath` and `searchXPath` properties in the example Thing Description of a Thing Directory into a single `things` property.

The rationale is discussed at length in #133 but the main reason is that property names should not contain verbs. A single `things` property seems to be the best way to model the collection of Thing Descriptions in the Directory's Thing Description.

A `sparql` property is kept separate from the things property due to the needs of conforming with the SPARQL specification, which mandates a particular URL structure and HTTP verbs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-discovery/pull/158.html" title="Last updated on Apr 30, 2021, 4:24 PM UTC (b075a81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/158/581dacc...benfrancis:b075a81.html" title="Last updated on Apr 30, 2021, 4:24 PM UTC (b075a81)">Diff</a>