### PR TITLE
Split registration event into multiple events

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -389,43 +389,106 @@
         }
     },
     "events": {
-        "registration": {
-            "description": "TD registration events",
-            "uriVariables": {
-                "type": {
-                    "title": "Event type(s)",
-                    "description": "Multiple types passed as type={type} pairs for SSE",
-                    "type": "string",
-                    "enum": [
-                        "create",
-                        "update",
-                        "delete"
-                    ]
-                },
-                "full": {
-                    "title": "Include TD changes inside event data",
-                    "type": "boolean"
-                }
-            },
-            "forms": [
-                {
-                    "op": "subscribeevent",
-                    "href": "/events{?type,full}",
-                    "subprotocol": "sse",
-                    "contentType": "text/event-stream",
-                    "htv:headers": [
-                        {
-                            "description": "ID of the last event provided by reconnecting clients",
-                            "htv:fieldName": "Last-Event-ID"
-                        }
-                    ],
-                    "data": {
-                        "description": "Partial or complete TD",
-                        "type": "object"
-                    },
-                    "scopes": "notifications"
-                }
-            ]
+        "thingCreated": {
+          "@type": "ThingCreatedEvent",
+          "title": "Thing created",
+          "data": {
+              "type": "object",
+              "description": "The schema of created TD event data including the created TD",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td": {
+                      "type": "object",
+                      "description": "The created TD in a create event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingcreated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingUpdated": {
+          "@type:": "ThingUpdatedEvent",
+          "title": "Thing updated",
+          "data": {
+              "type": "object",
+              "description": "The schema of updated TD event data including the TD updates",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td_updates": {
+                      "type": "object",
+                      "description": "The partial TD composed of modified TD parts in an update event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingupdated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingDeleted": {
+          "@type": "ThingDeletedEvent",
+          "title": "Thing deleted",
+          "data": {
+              "type": "object",
+              "description": "The schema of deleted TD event data",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingdeleted",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+           ]
         }
     }
 }


### PR DESCRIPTION
This PR proposes splitting the `registration` event of the Directory Service API into three separate events: `thingCreated`, `thingUpdated` and `thingDeleted`. As discussed in #133.

The rationale for combining these three event types into a single event in the first place was to make it easier to subscribe to all events at once. But this feels like an anti-pattern which is motivated by needing to work around limitations of the WoT Thing Description specification. It also makes it impossible for a Consumer to subscribe to individual events if that's what they want to do.

A normative Thing Description or Thing Model specified by the WoT Working Group should demonstrate best practices, and taking the combined approach may imply that it's a good practice for Web Things to combine all their event types into a single event to make it easier to subscribe to all events at the same time.

I have instead proposed new `subscribeallevents` and `unsubscribeallevents` operations for the Thing Description specification so that it could be possible to either subscribe to all events, or to individual events, depending on what the Consumer prefers.  See #1082.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-discovery/pull/159.html" title="Last updated on Apr 30, 2021, 4:24 PM UTC (e35690e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/159/581dacc...benfrancis:e35690e.html" title="Last updated on Apr 30, 2021, 4:24 PM UTC (e35690e)">Diff</a>