### PR TITLE
Rename actions to match properties and events

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -53,10 +53,12 @@
     "security": "combo_sc",
     "base": "https://tdd.example.com",
     "actions": {
-        "createTD": {
+        "createThing": {
+            "@type": "CreateThingAction",
             "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -64,7 +66,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -81,14 +83,14 @@
                     "scopes": "write"
                 },
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "POST",
                     "contentType": "application/td+json",
                     "response": {
                         "description": "Success response",
                         "htv:headers": [
                             {
-                                "description": "System-generated UUID (version 4) URN",
+                                "description": "System-generated URI",
                                 "htv:fieldName": "Location",
                                 "htv:fieldValue": ""
                             }
@@ -106,10 +108,11 @@
                 }
             ]
         },
-        "updateTD": {
+        "updateThing": {
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -117,7 +120,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -132,21 +135,9 @@
                         }
                     ],
                     "scopes": "write"
-                }
-            ]
-        },
-        "updatePartialTD": {
-            "description": "Update parts of a Thing Description",
-            "uriVariables": {
-                "id": {
-                    "title": "Thing Description ID",
-                    "type": "string",
-                    "format": "iri-reference"
-                }
-            },
-            "forms": [
+                },
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PATCH",
                     "contentType": "application/merge-patch+json",
                     "response": {
@@ -169,10 +160,11 @@
                 }
             ]
         },
-        "deleteTD": {
+        "deleteThing": {
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -180,7 +172,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "DELETE",
                     "response": {
                         "description": "Success response",

--- a/directory.td.json
+++ b/directory.td.json
@@ -136,6 +136,20 @@
                     ],
                     "scopes": "write"
                 },
+            ]
+        },
+        "partialUpdateThing": {
+            "@type": "PartialUpdateThingAction",
+            "description": "Update a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "@type": "ThingID",
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
                 {
                     "href": "/things/{id}",
                     "htv:methodName": "PATCH",

--- a/directory.td.json
+++ b/directory.td.json
@@ -91,8 +91,7 @@
                         "htv:headers": [
                             {
                                 "description": "System-generated URI",
-                                "htv:fieldName": "Location",
-                                "htv:fieldValue": ""
+                                "htv:fieldName": "Location"
                             }
                         ],
                         "htv:statusCodeValue": 201
@@ -109,6 +108,7 @@
             ]
         },
         "updateThing": {
+            "@type": "UpdateThingAction",
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
@@ -161,6 +161,7 @@
             ]
         },
         "deleteThing": {
+            "@type": "DeleteThingAction",
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {


### PR DESCRIPTION
This PR proposes renaming and combining actions and their API endpoints in the Directory Service API to match other proposed changes to the example Thing Directory Description (in #158 and #159):
- `createTD` -> `createThing`
- ~~`updateTD` & `updatePartialTD` -> `updateThing`~~
- `updateTD` -> `updateThing`
- `updatePartialTD` -> `partialUpdateThing`
- `deleteTD` -> `deleteThing`

See discussion in #133


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-discovery/pull/160.html" title="Last updated on May 18, 2021, 2:20 PM UTC (96cd40f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/160/581dacc...benfrancis:96cd40f.html" title="Last updated on May 18, 2021, 2:20 PM UTC (96cd40f)">Diff</a>