### PR TITLE
Rename DirectoryDescription to ThingDirectory

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -3,7 +3,7 @@
         "http://www.w3.org/ns/td",
         "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
     ],
-    "@type": "DirectoryDescription",
+    "@type": "ThingDirectory",
     "title": "Thing Description Directory (TDD)",
     "version": {
         "instance": "1.0.0-alpha"


### PR DESCRIPTION
This PR proposes renaming `DirectoryDescription` to `ThingDirectory` as discussed in #133 and #43


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-discovery/pull/161.html" title="Last updated on Apr 30, 2021, 4:25 PM UTC (6f96eb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/161/581dacc...benfrancis:6f96eb2.html" title="Last updated on Apr 30, 2021, 4:25 PM UTC (6f96eb2)">Diff</a>