### PR TITLE
Ignoring unknown event types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1325,6 +1325,7 @@ img.wot-diagram {
                                 the Thing Descriptions within the directory using 
                                 `create`, `update`, and `delete` event types.
                             </span>
+                            Clients should ignore any event with a type that is unknown to them.
                         </dd>
 
                         <dt>Event Filtering</dt>


### PR DESCRIPTION
As pointed in https://github.com/w3c/wot-discovery/pull/159#issuecomment-832111684, adding new event types may break existing clients. This PR adds a statement to enable event type extensions without breaking existing clients.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/170.html" title="Last updated on May 10, 2021, 2:10 PM UTC (4f678dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/170/13d6508...farshidtz:4f678dc.html" title="Last updated on May 10, 2021, 2:10 PM UTC (4f678dc)">Diff</a>