### PR TITLE
Remove payload-based event filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1503,7 +1503,8 @@ img.wot-diagram {
                                     At the absence of any `type` query parameter, the server will deliver all
                                     types of events.
                                 </li>
-                                <li>
+                                <!-- Commented for now. See the issue details below. -->
+                                <!-- <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-filter-search">
                                         The server MAY support event filtering based on the 
                                         search expressions passed as one of `jsonpath`, `xpath`, 
@@ -1523,8 +1524,11 @@ img.wot-diagram {
                                     </span>
                                     This is to inform the clients about the missing feature at the connection
                                     time and prevent unexpected network traffic and events.
-                                </li>
+                                </li> -->
                             </ul>
+                            <div class="issue" data-number="176">
+                                Event filtering based on the payload is work in progress. 
+                            </div>
                         </dd>
                         <dt>Event Data</dt>
                         <dd>


### PR DESCRIPTION
This section describes a minor feature which is subject to multiple issues (see #176).

The example was added after CR review. 

I propose removing it completely for now and considering it for the next version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/177.html" title="Last updated on May 17, 2021, 1:46 PM UTC (4ff78a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/177/3db135e...farshidtz:4ff78a6.html" title="Last updated on May 17, 2021, 1:46 PM UTC (4ff78a6)">Diff</a>