### PR TITLE
Create JSON Schema for validation of discovery extensions

### DIFF
--- a/validation/td-discovery-extensions-json-schema.json
+++ b/validation/td-discovery-extensions-json-schema.json
@@ -1,0 +1,32 @@
+{
+  "title": "WoT Discovery TD-extensions Schema - 21 May 2021",
+  "description": "JSON Schema for validating TD instances with WoT Discovery extensions",
+  "$schema ": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "properties": {
+    "registration": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "retrieved": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This may be used to validate the discovery extensions in combination to other schemas.

The JSON Schema for validation of native TD attributes: https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json
 
I used the following filename template to allow adding other formats (e.g. SHACL #143) and file extensions (e.g. ttl) in future:
```
/validation/td-discovery-extensions-{format}.{ext}
```