### PR TITLE
Refactor Directory Service API TD

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -3,7 +3,7 @@
         "http://www.w3.org/ns/td",
         "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
     ],
-    "@type": "DirectoryDescription",
+    "@type": "ThingDirectory",
     "title": "Thing Description Directory (TDD)",
     "version": {
         "instance": "1.0.0-alpha"

--- a/directory.td.json
+++ b/directory.td.json
@@ -53,10 +53,12 @@
     "security": "combo_sc",
     "base": "https://tdd.example.com",
     "actions": {
-        "createTD": {
+        "createThing": {
+            "@type": "CreateThingAction",
             "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -64,7 +66,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -81,14 +83,14 @@
                     "scopes": "write"
                 },
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "POST",
                     "contentType": "application/td+json",
                     "response": {
                         "description": "Success response",
                         "htv:headers": [
                             {
-                                "description": "System-generated UUID (version 4) URN",
+                                "description": "System-generated URI",
                                 "htv:fieldName": "Location",
                                 "htv:fieldValue": ""
                             }
@@ -106,10 +108,11 @@
                 }
             ]
         },
-        "updateTD": {
+        "updateThing": {
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -117,7 +120,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -132,21 +135,9 @@
                         }
                     ],
                     "scopes": "write"
-                }
-            ]
-        },
-        "updatePartialTD": {
-            "description": "Update parts of a Thing Description",
-            "uriVariables": {
-                "id": {
-                    "title": "Thing Description ID",
-                    "type": "string",
-                    "format": "iri-reference"
-                }
-            },
-            "forms": [
+                },
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PATCH",
                     "contentType": "application/merge-patch+json",
                     "response": {
@@ -169,10 +160,11 @@
                 }
             ]
         },
-        "deleteTD": {
+        "deleteThing": {
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -180,7 +172,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "DELETE",
                     "response": {
                         "description": "Success response",

--- a/directory.td.json
+++ b/directory.td.json
@@ -199,53 +199,45 @@
         }
     },
     "properties": {
-        "retrieveTD": {
-            "description": "Retrieve a Thing Description",
+        "things": {
+           "@type": "ThingListProperty",
+            "description": "Collection of Thing Descriptions in the directory",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/td/{id}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/td+json"
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "TD with the given id not found",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 404
-                        }
-                    ],
-                    "scopes": "read"
-                }
-            ]
-        },
-        "retrieveTDs": {
-            "description": "Retrieve all Thing Descriptions",
-            "uriVariables": {
+                },
+                "jsonpath": {
+                    "@type": "JSONPathExpression",
+                    "title": "A valid JSONPath expression",
+                    "type": "string"
+                },
+                "xpath": {
+                    "@type": "XPathExpression",
+                    "title": "A valid XPath expression",
+                    "type": "string"
+                },
                 "offset": {
+                    "@type": "PageOffset",
                     "title": "Number of TDs to skip before the page",
                     "type": "number",
                     "default": 0
                 },
                 "limit": {
+                    "@type": "PageLimit",
                     "title": "Number of TDs in a page",
                     "type": "number"
                 },
                 "sort_by": {
+                    "@type": "SortAttribute",
                     "title": "Comparator TD attribute for collection sorting",
                     "type": "string",
                     "default": "id"
                 },
                 "sort_order": {
+                    "@type": "SortOrder",
                     "title": "Sorting order",
                     "type": "string",
                     "enum": ["asc", "desc"],
@@ -254,17 +246,17 @@
             },
             "forms": [
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json"
+                        "contentType": "application/td+json"
                     },
                     "scopes": "readAll"
                 },
                 {
-                    "href": "/td{?offset,limit,sort_by,sort_order}",
+                    "href": "/things{?offset,limit,sort_by,sort_order}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -284,79 +276,30 @@
                         }
                     ],
                     "scopes": "readAll"
-                }
-            ]
-        },
-        "searchJSONPath": {
-            "description": "JSONPath syntactic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid JSONPath expression",
-                    "type": "string"
-                }
-            },
-            "forms": [
+                },
                 {
-                    "href": "/search/jsonpath?query={query}",
+                    "href": "/things/{id}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "TD with the given id not found",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 404
+                        }
+                    ],
+                    "scopes": "read"
+                },
+                {
+                    "href": "/things?jsonpath={jsonpath}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "contentType": "application/json",
-                        "htv:statusCodeValue": 200
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "JSONPath expression not provided or contains syntax errors",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "search"
-                }
-            ]
-        },
-        "searchXPath": {
-            "description": "XPath syntactic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid XPath expression",
-                    "type": "string"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/search/xpath?query={query}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "contentType": "application/json",
-                        "htv:statusCodeValue": 200
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "JSONPath expression not provided or contains syntax errors",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "search"
-                }
-            ]
-        },
-        "searchSPARQL": {
-            "description": "SPARQL semantic search",
-            "uriVariables": {
-                "query": {
-                    "title": "A valid SPARQL 1.1. query",
-                    "type": "string"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/search/sparql?query={query}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
                         "htv:statusCodeValue": 200
                     },
                     "additionalResponses": [
@@ -369,8 +312,8 @@
                     "scopes": "search"
                 },
                 {
-                    "href": "/search/sparql",
-                    "htv:methodName": "POST",
+                    "href": "/things?xpath={xpath}",
+                    "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
                         "contentType": "application/json",
@@ -378,7 +321,72 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "JSONPath expression not provided or contains syntax errors",
+                            "description": "XPath expression not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                }
+            ]
+        },
+        "sparql": {
+            "@type": "SPARQLProperty",
+            "description": "Endpoint for querying the directory with SPARQL",
+            "uriVariables": {
+                "query": {
+                    "@type": "SPARQLQuery",
+                    "title": "A valid SPARQL 1.1. query",
+                    "type": "string"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/sparql?query={query}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                },
+                {
+                    "href": "/sparql",
+                    "htv:methodName": "POST",
+                    "contentType:": "application/x-www-form-urlencoded",
+                    "response": {
+                        "description": "Success response",
+                        "contentType": "application/json",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "search"
+                },
+                {
+                    "href": "/sparql",
+                    "htv:methodName": "POST",
+                    "contentType:": "application/sparql-query",
+                    "response": {
+                        "description": "Success response",
+                        "contentType": "application/json",
+                        "htv:statusCodeValue": 200
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "SPARQL query not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }

--- a/directory.td.json
+++ b/directory.td.json
@@ -52,13 +52,72 @@
     },
     "security": "combo_sc",
     "base": "https://tdd.example.com",
+    "properties": {
+        "things": {
+            "description": "Collection of Thing Descriptions in the directory",
+            "uriVariables": {
+                "offset": {
+                    "title": "Number of TDs to skip before the page",
+                    "type": "number",
+                    "default": 0
+                },
+                "limit": {
+                    "title": "Number of TDs in a page",
+                    "type": "number"
+                },
+                "sort_by": {
+                    "title": "Comparator TD attribute for collection sorting",
+                    "type": "string",
+                    "default": "id"
+                },
+                "sort_order": {
+                    "title": "Sorting order",
+                    "type": "string",
+                    "enum": ["asc", "desc"],
+                    "default": "asc"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/things",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
+                    "scopes": "readAll"
+                },
+                {
+                    "href": "/things{?offset,limit,sort_by,sort_order}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/ld+json",
+                        "htv:headers": [
+                            {
+                                "htv:fieldName": "Link"
+                            }
+                        ]
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "Invalid query arguments",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "readAll"
+                }
+            ]
+        }
+    },
     "actions": {
         "createThing": {
-            "@type": "CreateThingAction",
             "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
-                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -107,12 +166,39 @@
                 }
             ]
         },
+        "retrieveThing": {
+            "description": "Retrieve an individual Thing Description by its ID",
+            "uriVariables": {
+                "id": {
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/things/{id}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "TD with the given id not found",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 404
+                        }
+                    ],
+                    "scopes": "read"
+                },
+            ]
+        },
         "updateThing": {
-            "@type": "UpdateThingAction",
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
-                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -139,11 +225,9 @@
             ]
         },
         "partialUpdateThing": {
-            "@type": "PartialUpdateThingAction",
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
-                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -175,11 +259,9 @@
             ]
         },
         "deleteThing": {
-            "@type": "DeleteThingAction",
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {
-                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -203,106 +285,18 @@
                     "scopes": "write"
                 }
             ]
-        }
-    },
-    "properties": {
-        "things": {
-           "@type": "ThingListProperty",
-            "description": "Collection of Thing Descriptions in the directory",
+        },
+        "searchJSONPath": {
+            "description": "JSONPath syntactic search",
             "uriVariables": {
-                "id": {
-                    "@type": "ThingID",
-                    "title": "Thing Description ID",
-                    "type": "string",
-                    "format": "iri-reference"
-                },
-                "jsonpath": {
-                    "@type": "JSONPathExpression",
+                "query": {
                     "title": "A valid JSONPath expression",
                     "type": "string"
-                },
-                "xpath": {
-                    "@type": "XPathExpression",
-                    "title": "A valid XPath expression",
-                    "type": "string"
-                },
-                "offset": {
-                    "@type": "PageOffset",
-                    "title": "Number of TDs to skip before the page",
-                    "type": "number",
-                    "default": 0
-                },
-                "limit": {
-                    "@type": "PageLimit",
-                    "title": "Number of TDs in a page",
-                    "type": "number"
-                },
-                "sort_by": {
-                    "@type": "SortAttribute",
-                    "title": "Comparator TD attribute for collection sorting",
-                    "type": "string",
-                    "default": "id"
-                },
-                "sort_order": {
-                    "@type": "SortOrder",
-                    "title": "Sorting order",
-                    "type": "string",
-                    "enum": ["asc", "desc"],
-                    "default": "asc"
                 }
             },
             "forms": [
                 {
-                    "href": "/things",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/td+json"
-                    },
-                    "scopes": "readAll"
-                },
-                {
-                    "href": "/things{?offset,limit,sort_by,sort_order}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json",
-                        "htv:headers": [
-                            {
-                                "htv:fieldName": "Link"
-                            }
-                        ]
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "Invalid query arguments",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "readAll"
-                },
-                {
-                    "href": "/things/{id}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/td+json"
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "TD with the given id not found",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 404
-                        }
-                    ],
-                    "scopes": "read"
-                },
-                {
-                    "href": "/things?jsonpath={jsonpath}",
+                    "href": "/search/jsonpath?query={query}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -317,9 +311,20 @@
                         }
                     ],
                     "scopes": "search"
-                },
+                }
+            ]
+        },
+        "searchXPath": {
+            "description": "XPath syntactic search",
+            "uriVariables": {
+                "query": {
+                    "title": "A valid XPath expression",
+                    "type": "string"
+                }
+            },
+            "forms": [
                 {
-                    "href": "/things?xpath={xpath}",
+                    "href": "/search/xpath?query={query}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -328,7 +333,7 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "XPath expression not provided or contains syntax errors",
+                            "description": "JSONPath expression not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }
@@ -337,19 +342,17 @@
                 }
             ]
         },
-        "sparql": {
-            "@type": "SPARQLProperty",
-            "description": "Endpoint for querying the directory with SPARQL",
+        "searchSPARQL": {
+            "description": "SPARQL semantic search",
             "uriVariables": {
                 "query": {
-                    "@type": "SPARQLQuery",
                     "title": "A valid SPARQL 1.1. query",
                     "type": "string"
                 }
             },
             "forms": [
                 {
-                    "href": "/sparql?query={query}",
+                    "href": "/search/sparql?query={query}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -365,9 +368,8 @@
                     "scopes": "search"
                 },
                 {
-                    "href": "/sparql",
+                    "href": "/search/sparql",
                     "htv:methodName": "POST",
-                    "contentType:": "application/x-www-form-urlencoded",
                     "response": {
                         "description": "Success response",
                         "contentType": "application/json",
@@ -375,25 +377,7 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "SPARQL query not provided or contains syntax errors",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "search"
-                },
-                {
-                    "href": "/sparql",
-                    "htv:methodName": "POST",
-                    "contentType:": "application/sparql-query",
-                    "response": {
-                        "description": "Success response",
-                        "contentType": "application/json",
-                        "htv:statusCodeValue": 200
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "SPARQL query not provided or contains syntax errors",
+                            "description": "JSONPath expression not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }
@@ -405,34 +389,21 @@
     },
     "events": {
         "thingCreated": {
-          "@type": "ThingCreatedEvent",
           "title": "Thing created",
           "data": {
-              "type": "object",
-              "description": "The schema of created TD event data including the created TD",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td": {
-                      "type": "object",
-                      "description": "The created TD in a create event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingcreated",
+                  "href": "/events?type=thingCreated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -440,34 +411,21 @@
           ]
         },
         "thingUpdated": {
-          "@type:": "ThingUpdatedEvent",
           "title": "Thing updated",
           "data": {
-              "type": "object",
-              "description": "The schema of updated TD event data including the TD updates",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td_updates": {
-                      "type": "object",
-                      "description": "The partial TD composed of modified TD parts in an update event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingupdated",
+                  "href": "/events?type=thingUpdated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -475,30 +433,21 @@
           ]
         },
         "thingDeleted": {
-          "@type": "ThingDeletedEvent",
           "title": "Thing deleted",
           "data": {
-              "type": "object",
-              "description": "The schema of deleted TD event data",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingdeleted",
+                  "href": "/events?type=thingDeleted",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"

--- a/directory.td.json
+++ b/directory.td.json
@@ -179,6 +179,8 @@
                 "type": "object",
                 "description": "The retrieved Thing Description"
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/things/{id}",
@@ -298,6 +300,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/jsonpath?query={query}",
@@ -326,6 +330,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/xpath?query={query}",
@@ -354,6 +360,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/sparql?query={query}",

--- a/directory.td.json
+++ b/directory.td.json
@@ -175,6 +175,10 @@
                     "format": "iri-reference"
                 }
             },
+            "output" : {
+                "type": "object",
+                "description": "The retrieved Thing Description"
+            },
             "forms": [
                 {
                     "href": "/things/{id}",

--- a/directory.td.json
+++ b/directory.td.json
@@ -136,6 +136,20 @@
                     ],
                     "scopes": "write"
                 },
+            ]
+        },
+        "partialUpdateThing": {
+            "@type": "PartialUpdateThingAction",
+            "description": "Update a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "@type": "ThingID",
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
                 {
                     "href": "/things/{id}",
                     "htv:methodName": "PATCH",

--- a/directory.td.json
+++ b/directory.td.json
@@ -91,8 +91,7 @@
                         "htv:headers": [
                             {
                                 "description": "System-generated URI",
-                                "htv:fieldName": "Location",
-                                "htv:fieldValue": ""
+                                "htv:fieldName": "Location"
                             }
                         ],
                         "htv:statusCodeValue": 201
@@ -109,6 +108,7 @@
             ]
         },
         "updateThing": {
+            "@type": "UpdateThingAction",
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
@@ -161,6 +161,7 @@
             ]
         },
         "deleteThing": {
+            "@type": "DeleteThingAction",
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {

--- a/directory.td.json
+++ b/directory.td.json
@@ -404,43 +404,106 @@
         }
     },
     "events": {
-        "registration": {
-            "description": "TD registration events",
-            "uriVariables": {
-                "type": {
-                    "title": "Event type(s)",
-                    "description": "Multiple types passed as type={type} pairs for SSE",
-                    "type": "string",
-                    "enum": [
-                        "create",
-                        "update",
-                        "delete"
-                    ]
-                },
-                "full": {
-                    "title": "Include TD changes inside event data",
-                    "type": "boolean"
-                }
-            },
-            "forms": [
-                {
-                    "op": "subscribeevent",
-                    "href": "/events{?type,full}",
-                    "subprotocol": "sse",
-                    "contentType": "text/event-stream",
-                    "htv:headers": [
-                        {
-                            "description": "ID of the last event provided by reconnecting clients",
-                            "htv:fieldName": "Last-Event-ID"
-                        }
-                    ],
-                    "data": {
-                        "description": "Partial or complete TD",
-                        "type": "object"
-                    },
-                    "scopes": "notifications"
-                }
-            ]
+        "thingCreated": {
+          "@type": "ThingCreatedEvent",
+          "title": "Thing created",
+          "data": {
+              "type": "object",
+              "description": "The schema of created TD event data including the created TD",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td": {
+                      "type": "object",
+                      "description": "The created TD in a create event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingcreated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingUpdated": {
+          "@type:": "ThingUpdatedEvent",
+          "title": "Thing updated",
+          "data": {
+              "type": "object",
+              "description": "The schema of updated TD event data including the TD updates",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td_updates": {
+                      "type": "object",
+                      "description": "The partial TD composed of modified TD parts in an update event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingupdated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingDeleted": {
+          "@type": "ThingDeletedEvent",
+          "title": "Thing deleted",
+          "data": {
+              "type": "object",
+              "description": "The schema of deleted TD event data",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingdeleted",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+           ]
         }
     }
 }


### PR DESCRIPTION
OK, here is my last attempt to re-factor the Thing Description to something which we may be able to reach a consensus on, before taking the nuclear option of #179

This PR is a combination of #158  #159, #160 and #161 based on the discussion in #133, but with compromises based on feedback on the original PRs and conversations in the last WoT Discovery call.

(Sorry this is one big PR but some people were asking me to combine PRs and some people were asking me to split them up further and this just seemed the easiest way to see all the related changes together.)

Below is a summary of the changes:

- `@type` - renamed `DirectoryDescription` to `ThingDirectory` to be more consistent with `Thing` and `ThingLink` as discussed in #133 and #43
- `properties`
  - `things` - Renamed from `retrieveTDs` so that the property name is a noun. 
- `actions`
  - `createThing` - Renamed from `createTD`
  - `retrieveThing` - Replaces `retrieveTD` property since it's a verb
  - `updateThing` - Renamed from `updateTD`
  - `partialUpdateThing` - Renamed from `updatePartialTD`
  - `deleteThing` - Renamed from `deleteTD`
  - `searchJSONPath` - Now an action rather than a property since it is a verb
  - `searchXPath` - Now an action rather than a property since it is a verb
  - `searchSPARQL` - Now an action rather than a property since it is a verb
- `events` - split out into three separate events, but keeping type as a query string in the URL
  - `thingCreated `
  - `thingUpdated`
  - `thingDeleted`

Notes:
- The interaction affordances for retrieving individual things and searching for things are now actions rather than properties as @mmccool suggested and @relu91 mentioned would be consistent with an OOP type programming model
- Pagination URL variables are still part of the things property since they operate on the collection of things rather than an individual thing. @farshidtz alluded to the fact that making pagination an action would be silly.
- I've separated out the events into three separate event affordances but kept the `type` query string in the URL, since @farshidtz said he'd be OK with splitting the event affordance as long as the `type` query string was still in the URL
  - Note that the [`subscribeallevents`](https://github.com/w3c/wot-thing-description/issues/1082) feature will be needed in the Thing Description specification in order to describe how to subscribe to all events at once
- I've kept `updateThing` and `partialUpdateThing` separate interactions to alleviate concerns about including both a PUT and PATCH form in the same interaction affordance, and so that https://github.com/w3c/wot-thing-description/issues/1143 is not necessary in the Thing Description specification
- I've removed the semantic annotations for all the interaction affordances, data schemas and URI variables since they are largely redundant if the interaction affordance names and URL structure are normatively defined in the specification as @mmccool thinks they should be
- The TD still tries to describe the Directory Service API using Forms, but hopefully those forms are now _slightly_ (but not much) simpler by splitting some things out (which is @egekorkan's main concern)

Things I like about this compromise:
1. Property names are now nouns
2. Action names are now verbs
2. Each event type now has its own event affordance

Things I don't like about this compromise:
1. Retrieval and search features are actions. In my view these features should be part of the things property because they each just provide a different filtered view of the data in the things property and don't change state in any way. It feels inconsistent to have retrieving the whole list of things and paginating that list as a property, whilst retrieving a single thing or searching the list by JSONPath/XPath/SPARQL is an action.
2. The names of interaction affordances, URLs and URL variables are hard coded in the specification. In my opinion this is too prescriptive and developers should have the freedom to choose their own affordance names and URL structure, by using semantic annotations to identify which is which.
3. Event URLs use query strings instead of paths to identify different events. I don't really understand the reason why this is better.

I still don't think Thing Descriptions are well suited to describing a web service like the Directory Service API (as opposed to the capabilities of physical devices). I also suspect that #179 could actually be a quicker route to workable specification within the time-frame of the current charter. However, please let me know whether you think this could be a workable compromise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-discovery/pull/184.html" title="Last updated on May 31, 2021, 1:47 PM UTC (4dbbe47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/184/581dacc...benfrancis:4dbbe47.html" title="Last updated on May 31, 2021, 1:47 PM UTC (4dbbe47)">Diff</a>