### PR TITLE
Refactor Directory Service API TD (stage 1)

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -53,10 +53,12 @@
     "security": "combo_sc",
     "base": "https://tdd.example.com",
     "actions": {
-        "createTD": {
+        "createThing": {
+            "@type": "CreateThingAction",
             "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -64,7 +66,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -81,14 +83,14 @@
                     "scopes": "write"
                 },
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "POST",
                     "contentType": "application/td+json",
                     "response": {
                         "description": "Success response",
                         "htv:headers": [
                             {
-                                "description": "System-generated UUID (version 4) URN",
+                                "description": "System-generated URI",
                                 "htv:fieldName": "Location",
                                 "htv:fieldValue": ""
                             }
@@ -106,10 +108,11 @@
                 }
             ]
         },
-        "updateTD": {
+        "updateThing": {
             "description": "Update a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -117,7 +120,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PUT",
                     "contentType": "application/td+json",
                     "response": {
@@ -132,21 +135,9 @@
                         }
                     ],
                     "scopes": "write"
-                }
-            ]
-        },
-        "updatePartialTD": {
-            "description": "Update parts of a Thing Description",
-            "uriVariables": {
-                "id": {
-                    "title": "Thing Description ID",
-                    "type": "string",
-                    "format": "iri-reference"
-                }
-            },
-            "forms": [
+                },
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "PATCH",
                     "contentType": "application/merge-patch+json",
                     "response": {
@@ -169,10 +160,11 @@
                 }
             ]
         },
-        "deleteTD": {
+        "deleteThing": {
             "description": "Delete a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -180,7 +172,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "DELETE",
                     "response": {
                         "description": "Success response",

--- a/directory.td.json
+++ b/directory.td.json
@@ -17,7 +17,8 @@
             "scopes": [
                 "write",
                 "read",
-                "search"
+                "search",
+                "notification"
             ]
         },
         "oauth2_client": {
@@ -27,7 +28,8 @@
             "scopes": [
                 "write",
                 "read",
-                "search"
+                "search",
+                "notification"
             ]
         },
         "oauth2_device": {
@@ -38,7 +40,8 @@
             "scopes": [
                 "write",
                 "read",
-                "search"
+                "search",
+                "notification"
             ]
         },
         "combo_sc": {
@@ -54,7 +57,6 @@
     "base": "https://tdd.example.com",
     "actions": {
         "createThing": {
-            "@type": "CreateThingAction",
             "description": "Create a Thing Description",
             "uriVariables": {
                 "id": {
@@ -91,8 +93,7 @@
                         "htv:headers": [
                             {
                                 "description": "System-generated URI",
-                                "htv:fieldName": "Location",
-                                "htv:fieldValue": ""
+                                "htv:fieldName": "Location"
                             }
                         ],
                         "htv:statusCodeValue": 201
@@ -135,12 +136,11 @@
                         }
                     ],
                     "scopes": "write"
-                },
+                }
             ]
         },
         "partialUpdateThing": {
-            "@type": "PartialUpdateThingAction",
-            "description": "Update a Thing Description",
+            "description": "Partially update a Thing Description",
             "uriVariables": {
                 "id": {
                     "@type": "ThingID",
@@ -205,10 +205,11 @@
         }
     },
     "properties": {
-        "retrieveTD": {
+        "retrieveThing": {
             "description": "Retrieve a Thing Description",
             "uriVariables": {
                 "id": {
+                    "@type": "ThingID",
                     "title": "Thing Description ID",
                     "type": "string",
                     "format": "iri-reference"
@@ -216,7 +217,7 @@
             },
             "forms": [
                 {
-                    "href": "/td/{id}",
+                    "href": "/things/{id}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -234,7 +235,7 @@
                 }
             ]
         },
-        "retrieveTDs": {
+        "retrieveThings": {
             "description": "Retrieve all Thing Descriptions",
             "uriVariables": {
                 "offset": {
@@ -260,7 +261,7 @@
             },
             "forms": [
                 {
-                    "href": "/td",
+                    "href": "/things",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -270,7 +271,7 @@
                     "scopes": "readAll"
                 },
                 {
-                    "href": "/td{?offset,limit,sort_by,sort_order}",
+                    "href": "/things{?offset,limit,sort_by,sort_order}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
@@ -340,7 +341,7 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "JSONPath expression not provided or contains syntax errors",
+                            "description": "XPath expression not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }
@@ -367,7 +368,7 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "JSONPath expression not provided or contains syntax errors",
+                            "description": "SPARQL query not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }
@@ -384,7 +385,7 @@
                     },
                     "additionalResponses": [
                         {
-                            "description": "JSONPath expression not provided or contains syntax errors",
+                            "description": "SPARQL query not provided or contains syntax errors",
                             "contentType": "application/problem+json",
                             "htv:statusCodeValue": 400
                         }
@@ -395,12 +396,12 @@
         }
     },
     "events": {
-        "registration": {
-            "description": "TD registration events",
+        "thingRegistration": {
+            "description": "Thing Description registration events",
             "uriVariables": {
                 "type": {
                     "title": "Event type(s)",
-                    "description": "Multiple types passed as type={type} pairs for SSE",
+                    "description": "Zero or more event types server-side event filtering",
                     "type": "string",
                     "enum": [
                         "create",
@@ -429,7 +430,7 @@
                         "description": "Partial or complete TD",
                         "type": "object"
                     },
-                    "scopes": "notifications"
+                    "scopes": "notification"
                 }
             ]
         }

--- a/directory.td.json
+++ b/directory.td.json
@@ -136,6 +136,20 @@
                     ],
                     "scopes": "write"
                 },
+            ]
+        },
+        "partialUpdateThing": {
+            "@type": "PartialUpdateThingAction",
+            "description": "Update a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "@type": "ThingID",
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
                 {
                     "href": "/things/{id}",
                     "htv:methodName": "PATCH",

--- a/directory.td.json
+++ b/directory.td.json
@@ -144,7 +144,7 @@
                 }
             ]
         },
-        "partialUpdateThing": {
+        "partiallyUpdateThing": {
             "description": "Partially update a Thing Description",
             "uriVariables": {
                 "id": {

--- a/directory.td.json
+++ b/directory.td.json
@@ -83,13 +83,18 @@
                         }
                     ],
                     "scopes": "write"
-                },
+                }
+            ]
+        },
+        "createAnonymousThing": {
+            "description": "Create an anonymous Thing Description",
+            "forms": [
                 {
                     "href": "/things",
                     "htv:methodName": "POST",
                     "contentType": "application/td+json",
                     "response": {
-                        "description": "Success response",
+                        "description": "Success response including the system-generated URI",
                         "htv:headers": [
                             {
                                 "description": "System-generated URI",

--- a/index.html
+++ b/index.html
@@ -1167,7 +1167,7 @@ img.wot-diagram {
                                 </p>
 
                                 <p>
-                                    This operation is specified as `partialUpdateThing` property in 
+                                    This operation is specified as `partiallyUpdateThing` property in 
                                     [[[#directory-thing-description]]].
                                 </p>
                                 

--- a/index.html
+++ b/index.html
@@ -899,9 +899,7 @@ img.wot-diagram {
                                 A TD which is identified with an `id` attribute MUST be handled 
                                 differently with one that has no identifier (<a>Anonymous TD</a>).
                             </span>
-                            The create operations are specified as `createTD` action in 
-                            [[[#directory-thing-description]]]
-                            and elaborated below:
+                            The create operations are elaborated below:
                         </p>
                         <ul>
                             <li>
@@ -919,6 +917,10 @@ img.wot-diagram {
                                     the request shall instead proceed as an Update operation and respond
                                     the appropriate status code (see Update section).
                                 </p>
+                                <p>
+                                    The create operation for <a>TD</a>s that have identifiers is specified
+                                    as `createThing` action in [[[#directory-thing-description]]]. 
+                                </p>
                             </li>
                             <li>
                                 <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td">
@@ -928,11 +930,15 @@ img.wot-diagram {
                                     Upon successful processing, the server MUST respond with 201 (Created) status
                                     and a Location header containing a system-generated identifier for the TD.
                                 </span>
-                                <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td-generated-id"></span>
+                                <span class="rfc2119-assertion" id="tdd-reg-create-anonymous-td-generated-id">
                                     The identifier SHOULD be a UUID Version 4 [[RFC4122]].
                                 </span>
                                 That is a random or pseudo-random number which does not carry unintended information
                                 about the host or the resource.
+                                <p>
+                                    The create operation for <a>Anonymous TD</a>s is specified as `createAnonymousThing` action in 
+                                    [[[#directory-thing-description]]].
+                                </p>
                             </li>
                         </ul>
 
@@ -970,8 +976,10 @@ img.wot-diagram {
                                 A successful response MUST have 200 (OK) status, contain `application/td+json`
                                 Content-Type header, and the requested TD in body.
                             </span>
-                            The retrieve operation is specified as `retrieveTD` property in 
-                            [[[#directory-thing-description]]].
+                            <p>
+                                The retrieve operation is specified as `retrieveThing` property in 
+                                [[[#directory-thing-description]]].
+                            </p>
                         </p>
 
                         <p>
@@ -1109,7 +1117,7 @@ img.wot-diagram {
                                 </p>
 
                                 <p>
-                                    This operation is specified as `updateTD` property in 
+                                    This operation is specified as `updateThing` property in 
                                     [[[#directory-thing-description]]].
                                 </p>
                                 
@@ -1159,7 +1167,7 @@ img.wot-diagram {
                                 </p>
 
                                 <p>
-                                    This operation is specified as `updatePartialTD` property in 
+                                    This operation is specified as `partialUpdateThing` property in 
                                     [[[#directory-thing-description]]].
                                 </p>
                                 
@@ -1205,7 +1213,7 @@ img.wot-diagram {
                             <span class="rfc2119-assertion" id="tdd-reg-delete-resp">
                                 A successful response MUST have 204 (No Content) status.
                             </span>
-                            The retrieve operation is specified as `deleteTD` property in
+                            The retrieve operation is specified as `deleteThing` property in
                             [[[#directory-thing-description]]].
                         </p>
 
@@ -1389,7 +1397,7 @@ img.wot-diagram {
                         </p>
 
                         <p>    
-                            The paginated list operation is specified as `retrieveTDs` property in 
+                            The listing operation is specified as `retrieveThings` property in 
                             [[[#directory-thing-description]]].
                         </p>
 
@@ -1485,7 +1493,7 @@ img.wot-diagram {
                         In particular, the server responds to successful requests with 200 (OK) status
                         and `text/event-stream` Content Type. Re-connecting clients may continue from
                         the last event by providing the last event ID as `Last-Event-ID` header value.
-                        This API is specified as `registration` event in [[[#directory-thing-description]]].
+                        This API is specified as `thingRegistration` event in [[[#directory-thing-description]]].
                     </p>
 
                     <dl>


### PR DESCRIPTION
- Cherry picked some commits from #184 related to renaming actions and paths. 
- Renamed properties
- Separated create forms into multiple actions; see https://github.com/w3c/wot-discovery/pull/160#issuecomment-842437044
- Update the text to reflect the above changes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/188.html" title="Last updated on May 31, 2021, 2:55 PM UTC (416f993)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/188/3ae8fd8...farshidtz:416f993.html" title="Last updated on May 31, 2021, 2:55 PM UTC (416f993)">Diff</a>