### PR TITLE
Refactor Directory Service API TD (retrieve one and search as actions, listing as things property)

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -185,6 +185,8 @@
                     "format": "iri-reference"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/things/{id}",
@@ -307,6 +309,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/jsonpath?query={query}",
@@ -335,6 +339,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/xpath?query={query}",
@@ -363,6 +369,8 @@
                     "type": "string"
                 }
             },
+            "safe": true,
+            "idempotent": true,
             "forms": [
                 {
                     "href": "/search/sparql?query={query}",

--- a/directory.td.json
+++ b/directory.td.json
@@ -17,6 +17,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search",
                 "notification"
             ]
@@ -28,6 +29,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search",
                 "notification"
             ]
@@ -40,6 +42,7 @@
             "scopes": [
                 "write",
                 "read",
+                "readAll",
                 "search",
                 "notification"
             ]

--- a/directory.td.json
+++ b/directory.td.json
@@ -55,6 +55,67 @@
     },
     "security": "combo_sc",
     "base": "https://tdd.example.com",
+    "properties": {
+        "retrieveThings": {
+            "description": "Retrieve all Thing Descriptions",
+            "uriVariables": {
+                "offset": {
+                    "title": "Number of TDs to skip before the page",
+                    "type": "number",
+                    "default": 0
+                },
+                "limit": {
+                    "title": "Number of TDs in a page",
+                    "type": "number"
+                },
+                "sort_by": {
+                    "title": "Comparator TD attribute for collection sorting",
+                    "type": "string",
+                    "default": "id"
+                },
+                "sort_order": {
+                    "title": "Sorting order",
+                    "type": "string",
+                    "enum": ["asc", "desc"],
+                    "default": "asc"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/things",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/ld+json"
+                    },
+                    "scopes": "readAll"
+                },
+                {
+                    "href": "/things{?offset,limit,sort_by,sort_order}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/ld+json",
+                        "htv:headers": [
+                            {
+                                "htv:fieldName": "Link"
+                            }
+                        ]
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "Invalid query arguments",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 400
+                        }
+                    ],
+                    "scopes": "readAll"
+                }
+            ]
+        }
+    },
     "actions": {
         "createThing": {
             "description": "Create a Thing Description",
@@ -111,6 +172,36 @@
                         }
                     ],
                     "scopes": "write"
+                }
+            ]
+        },
+        "retrieveThing": {
+            "description": "Retrieve a Thing Description",
+            "uriVariables": {
+                "id": {
+                    "@type": "ThingID",
+                    "title": "Thing Description ID",
+                    "type": "string",
+                    "format": "iri-reference"
+                }
+            },
+            "forms": [
+                {
+                    "href": "/things/{id}",
+                    "htv:methodName": "GET",
+                    "response": {
+                        "description": "Success response",
+                        "htv:statusCodeValue": 200,
+                        "contentType": "application/td+json"
+                    },
+                    "additionalResponses": [
+                        {
+                            "description": "TD with the given id not found",
+                            "contentType": "application/problem+json",
+                            "htv:statusCodeValue": 404
+                        }
+                    ],
+                    "scopes": "read"
                 }
             ]
         },
@@ -205,97 +296,6 @@
                         }
                     ],
                     "scopes": "write"
-                }
-            ]
-        }
-    },
-    "properties": {
-        "retrieveThing": {
-            "description": "Retrieve a Thing Description",
-            "uriVariables": {
-                "id": {
-                    "@type": "ThingID",
-                    "title": "Thing Description ID",
-                    "type": "string",
-                    "format": "iri-reference"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/things/{id}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/td+json"
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "TD with the given id not found",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 404
-                        }
-                    ],
-                    "scopes": "read"
-                }
-            ]
-        },
-        "retrieveThings": {
-            "description": "Retrieve all Thing Descriptions",
-            "uriVariables": {
-                "offset": {
-                    "title": "Number of TDs to skip before the page",
-                    "type": "number",
-                    "default": 0
-                },
-                "limit": {
-                    "title": "Number of TDs in a page",
-                    "type": "number"
-                },
-                "sort_by": {
-                    "title": "Comparator TD attribute for collection sorting",
-                    "type": "string",
-                    "default": "id"
-                },
-                "sort_order": {
-                    "title": "Sorting order",
-                    "type": "string",
-                    "enum": ["asc", "desc"],
-                    "default": "asc"
-                }
-            },
-            "forms": [
-                {
-                    "href": "/things",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json"
-                    },
-                    "scopes": "readAll"
-                },
-                {
-                    "href": "/things{?offset,limit,sort_by,sort_order}",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json",
-                        "htv:headers": [
-                            {
-                                "htv:fieldName": "Link"
-                            }
-                        ]
-                    },
-                    "additionalResponses": [
-                        {
-                            "description": "Invalid query arguments",
-                            "contentType": "application/problem+json",
-                            "htv:statusCodeValue": 400
-                        }
-                    ],
-                    "scopes": "readAll"
                 }
             ]
         },

--- a/directory.td.json
+++ b/directory.td.json
@@ -56,7 +56,7 @@
     "security": "combo_sc",
     "base": "https://tdd.example.com",
     "properties": {
-        "retrieveThings": {
+        "things": {
             "description": "Retrieve all Thing Descriptions",
             "uriVariables": {
                 "offset": {

--- a/index.html
+++ b/index.html
@@ -977,7 +977,7 @@ img.wot-diagram {
                                 Content-Type header, and the requested TD in body.
                             </span>
                             <p>
-                                The retrieve operation is specified as `retrieveThing` property in 
+                                The retrieve operation is specified as `retrieveThing` action in 
                                 [[[#directory-thing-description]]].
                             </p>
                         </p>
@@ -1406,7 +1406,7 @@ img.wot-diagram {
                         </p>
 
                         <p>    
-                            The listing operation is specified as `retrieveThings` property in 
+                            The listing operation is specified as `things` property in 
                             [[[#directory-thing-description]]].
                         </p>
 
@@ -1724,7 +1724,7 @@ img.wot-diagram {
                             <code>application/json</code> Content-Type header, and in
                             the body a set of complete TDs or a set of TD fragments.
                         </span>
-                        The syntactic search with JSONPath is specified as `searchJSONPath` property in
+                        The syntactic search with JSONPath is specified as `searchJSONPath` action in
                         [[[#directory-thing-description]]].
 
                         <p>List of errors:
@@ -1753,7 +1753,7 @@ img.wot-diagram {
                             <code>application/json</code> Content-Type header, and in
                             the body a set of complete TDs or a set of TD fragments.
                         </span>
-                        The syntactic search with XPath is specified as `searchXPath` property in
+                        The syntactic search with XPath is specified as `searchXPath` action in
                         [[[#directory-thing-description]]].
                                 
                         <p>List of errors:
@@ -1786,7 +1786,7 @@ img.wot-diagram {
                             <code>application/json</code> for <code>SELECT</code> or <code>ASK</code>.
                             The response body MAY contain TD fragments or a set of TDs depending on the query.
                         </span>
-                        The semantic search with SPARQL is specified as `searchSPARQL` property in
+                        The semantic search with SPARQL is specified as `searchSPARQL` action in
                         [[[#directory-thing-description]]].
                         <p>List of errors:
                             <ul>


### PR DESCRIPTION
This PR takes parts of #184. In particular:

- Renaming `retrieveThings` property to `things`
- Moving `retrieveThing` to actions (safe and idempotent)
- Moving `searchJSONPath`, `searchXPath`, `searchSPARQL` to actions (safe and idempotent)

In addition:
- Adds the missing `readAll` scope
- Updated the text to reflect the above changes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/191.html" title="Last updated on Jun 1, 2021, 10:08 AM UTC (351de53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/191/077ca05...farshidtz:351de53.html" title="Last updated on Jun 1, 2021, 10:08 AM UTC (351de53)">Diff</a>