### PR TITLE
Refactor Directory Service API TD (split events) 

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -403,67 +403,79 @@
     "events": {
         "thingCreated": {
           "title": "Thing created",
+          "uriVariables": {
+            "full": {
+                "title": "Include TD changes inside event data",
+                "type": "boolean"
+            }
+          },
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial/Full TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingCreated",
+                  "href": "/events?type=create{&full}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
           ]
         },
         "thingUpdated": {
           "title": "Thing updated",
+          "uriVariables": {
+            "full": {
+                "title": "Include TD changes inside event data",
+                "type": "boolean"
+            }
+          },
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingUpdated",
+                  "href": "/events?type=update{&full}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
           ]
         },
         "thingDeleted": {
           "title": "Thing deleted",
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingDeleted",
+                  "href": "/events?type=delete",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
            ]
         }

--- a/directory.td.json
+++ b/directory.td.json
@@ -402,34 +402,21 @@
     },
     "events": {
         "thingCreated": {
-          "@type": "ThingCreatedEvent",
           "title": "Thing created",
           "data": {
-              "type": "object",
-              "description": "The schema of created TD event data including the created TD",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td": {
-                      "type": "object",
-                      "description": "The created TD in a create event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingcreated",
+                  "href": "/events?type=thingCreated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -437,34 +424,21 @@
           ]
         },
         "thingUpdated": {
-          "@type:": "ThingUpdatedEvent",
           "title": "Thing updated",
           "data": {
-              "type": "object",
-              "description": "The schema of updated TD event data including the TD updates",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td_updates": {
-                      "type": "object",
-                      "description": "The partial TD composed of modified TD parts in an update event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingupdated",
+                  "href": "/events?type=thingUpdated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -472,30 +446,21 @@
           ]
         },
         "thingDeleted": {
-          "@type": "ThingDeletedEvent",
           "title": "Thing deleted",
           "data": {
-              "type": "object",
-              "description": "The schema of deleted TD event data",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingdeleted",
+                  "href": "/events?type=thingDeleted",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"

--- a/directory.td.json
+++ b/directory.td.json
@@ -401,43 +401,106 @@
         }
     },
     "events": {
-        "thingRegistration": {
-            "description": "Thing Description registration events",
-            "uriVariables": {
-                "type": {
-                    "title": "Event type(s)",
-                    "description": "Zero or more event types server-side event filtering",
-                    "type": "string",
-                    "enum": [
-                        "create",
-                        "update",
-                        "delete"
-                    ]
-                },
-                "full": {
-                    "title": "Include TD changes inside event data",
-                    "type": "boolean"
-                }
-            },
-            "forms": [
-                {
-                    "op": "subscribeevent",
-                    "href": "/events{?type,full}",
-                    "subprotocol": "sse",
-                    "contentType": "text/event-stream",
-                    "htv:headers": [
-                        {
-                            "description": "ID of the last event provided by reconnecting clients",
-                            "htv:fieldName": "Last-Event-ID"
-                        }
-                    ],
-                    "data": {
-                        "description": "Partial or complete TD",
-                        "type": "object"
-                    },
-                    "scopes": "notification"
-                }
-            ]
+        "thingCreated": {
+          "@type": "ThingCreatedEvent",
+          "title": "Thing created",
+          "data": {
+              "type": "object",
+              "description": "The schema of created TD event data including the created TD",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td": {
+                      "type": "object",
+                      "description": "The created TD in a create event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingcreated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingUpdated": {
+          "@type:": "ThingUpdatedEvent",
+          "title": "Thing updated",
+          "data": {
+              "type": "object",
+              "description": "The schema of updated TD event data including the TD updates",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td_updates": {
+                      "type": "object",
+                      "description": "The partial TD composed of modified TD parts in an update event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingupdated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingDeleted": {
+          "@type": "ThingDeletedEvent",
+          "title": "Thing deleted",
+          "data": {
+              "type": "object",
+              "description": "The schema of deleted TD event data",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingdeleted",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+           ]
         }
     }
 }

--- a/directory.td.json
+++ b/directory.td.json
@@ -404,8 +404,8 @@
         "thingCreation": {
           "description": "Registration of Thing Descriptions inside the directory",
           "uriVariables": {
-            "full": {
-                "title": "Include TD changes inside event data",
+            "diff": {
+                "description": "Receive the full created TD as event data",
                 "type": "boolean"
             }
           },
@@ -416,7 +416,7 @@
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=create{&full}",
+                  "href": "/events?type=create{&diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
@@ -432,19 +432,20 @@
         "thingUpdate": {
           "description": "Updates to Thing Descriptions within the directory",
           "uriVariables": {
-            "full": {
-                "title": "Include TD changes inside event data",
+            "diff": {
+                "description": "Include TD changes inside event data",
                 "type": "boolean"
             }
           },
           "data": {
             "title": "Partial TD",
-            "type": "object"
+            "type": "object",
+            "contentMediaType": "application/merge-patch+json"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=update{&full}",
+                  "href": "/events?type=update{&diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -401,8 +401,8 @@
         }
     },
     "events": {
-        "thingCreated": {
-          "title": "Thing created",
+        "thingCreation": {
+          "description": "Registration of Thing Descriptions inside the directory",
           "uriVariables": {
             "full": {
                 "title": "Include TD changes inside event data",
@@ -429,8 +429,8 @@
               }
           ]
         },
-        "thingUpdated": {
-          "title": "Thing updated",
+        "thingUpdate": {
+          "description": "Updates to Thing Descriptions within the directory",
           "uriVariables": {
             "full": {
                 "title": "Include TD changes inside event data",
@@ -457,8 +457,8 @@
               }
           ]
         },
-        "thingDeleted": {
-          "title": "Thing deleted",
+        "thingDeletion": {
+          "description": "Deletion of Thing Descriptions from the directory",
           "data": {
             "title": "Partial TD",
             "type": "object"

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,6 @@ img.wot-diagram {
                         In particular, the server responds to successful requests with 200 (OK) status
                         and `text/event-stream` Content Type. Re-connecting clients may continue from
                         the last event by providing the last event ID as `Last-Event-ID` header value.
-                        This API is specified as `thingRegistration` event in [[[#directory-thing-description]]].
                     </p>
 
                     <dl>
@@ -1667,6 +1666,11 @@ img.wot-diagram {
                             </ul>
                         </dd>
                     </dl>
+                    <p>
+                        The Notification API is specified as three event affordances in
+                        [[[#directory-thing-description]]], namely:
+                        `thingCreation`, `thingUpdate`, and `thingDeletion`.
+                    </p>
 
                     <p class="ednote" title="SSE Authorization Header">
                         Some early SSE implementations (including HTML5 EventSource) do not allow

--- a/index.html
+++ b/index.html
@@ -1586,7 +1586,7 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-create-full">
-                                        When `full` query parameter is set to `true` and the event has `create` type,
+                                        When `diff` query parameter is set to `true` and the event has `create` type,
                                         the server MAY return the whole TD object as event data.
                                     </span>
                                     
@@ -1619,12 +1619,12 @@ img.wot-diagram {
                                     </aside>
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full">
-                                        When `full` query parameter is set to `true` and the event has `update` type,
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-update-diff">
+                                        When `diff` query parameter is set to `true` and the event has `update` type,
                                         the server MAY inform the client about the updated parts following the
                                         JSON Merge Patch [[RFC7396]] format.
                                     </span>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full-id">
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-update-id">
                                         An `update` event data that is based on JSON Merge Patch [[RFC7396]]
                                         MUST always include the identifier of the TD regardless of whether it
                                         is changed.
@@ -1646,16 +1646,15 @@ img.wot-diagram {
                                     </p>
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full">
-                                        The `full` query parameter MUST be ignored for `delete` events.
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-delete-diff">
+                                        The `diff` query parameter MUST be ignored for `delete` events.
                                     </span>
-                                    In other words, when the `full` query parameter is set to `true` and
-                                    the event has `delete` type, the server must only provide the identifier
-                                    in event data.
+                                    In other words, the server does not need to include additional properties in
+                                    the payload of `delete` events when `diff` is set to `true`. 
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-change-unsupported">
-                                        When a server which does not support the `full` query parameter 
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported">
+                                        When a server which does not support the `diff` query parameter 
                                         is requested with such query parameter, it MUST
                                         reject the request with 501 (Not Implemented) status.
                                     </span>


### PR DESCRIPTION
This PR takes events-splitting parts of #184. 
 
In addition:
- [x] Add back `full` URI variable
- [x] Rename `full` to `diff`
- [x] Revert event type values; needs further discussion: #197
- [x] Rename affordance names to nouns: `thingCreation`, `thingUpdate`, `thingDeletion`
- [x] Updates the text to reflect these changes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/196.html" title="Last updated on Jun 5, 2021, 5:18 PM UTC (8ccc0ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/196/89e9932...farshidtz:8ccc0ff.html" title="Last updated on Jun 5, 2021, 5:18 PM UTC (8ccc0ff)">Diff</a>