### PR TITLE
Notification API: pass event type in HTTP path instead of query

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -403,67 +403,79 @@
     "events": {
         "thingCreated": {
           "title": "Thing created",
+          "uriVariables": {
+            "full": {
+                "title": "Include TD changes inside event data",
+                "type": "boolean"
+            }
+          },
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial/Full TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingCreated",
+                  "href": "/events?type=create{&full}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
           ]
         },
         "thingUpdated": {
           "title": "Thing updated",
+          "uriVariables": {
+            "full": {
+                "title": "Include TD changes inside event data",
+                "type": "boolean"
+            }
+          },
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingUpdated",
+                  "href": "/events?type=update{&full}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
           ]
         },
         "thingDeleted": {
           "title": "Thing deleted",
           "data": {
-              "description": "Partial or complete TD",
-              "type": "object"
+            "title": "Partial TD",
+            "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=thingDeleted",
+                  "href": "/events?type=delete",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
-                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldName": "Last-Event-ID"
                       }
                   ],
-                  "scopes": "notifications"
+                  "scopes": "notification"
               }
            ]
         }

--- a/directory.td.json
+++ b/directory.td.json
@@ -402,34 +402,21 @@
     },
     "events": {
         "thingCreated": {
-          "@type": "ThingCreatedEvent",
           "title": "Thing created",
           "data": {
-              "type": "object",
-              "description": "The schema of created TD event data including the created TD",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td": {
-                      "type": "object",
-                      "description": "The created TD in a create event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingcreated",
+                  "href": "/events?type=thingCreated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -437,34 +424,21 @@
           ]
         },
         "thingUpdated": {
-          "@type:": "ThingUpdatedEvent",
           "title": "Thing updated",
           "data": {
-              "type": "object",
-              "description": "The schema of updated TD event data including the TD updates",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  },
-                  "td_updates": {
-                      "type": "object",
-                      "description": "The partial TD composed of modified TD parts in an update event"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingupdated",
+                  "href": "/events?type=thingUpdated",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"
@@ -472,30 +446,21 @@
           ]
         },
         "thingDeleted": {
-          "@type": "ThingDeletedEvent",
           "title": "Thing deleted",
           "data": {
-              "type": "object",
-              "description": "The schema of deleted TD event data",
-              "properties": {
-                  "td_id": {
-                      "type": "string",
-                      "format": "iri-reference",
-                      "description": "Identifier of TD in directory"
-                  }
-              }
+              "description": "Partial or complete TD",
+              "type": "object"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events/thingdeleted",
+                  "href": "/events?type=thingDeleted",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
                       {
                           "description": "ID of the last event for reconnection",
                           "htv:fieldName": "Last-Event-ID",
-                          "htv:fieldValue": ""
                       }
                   ],
                   "scopes": "notifications"

--- a/directory.td.json
+++ b/directory.td.json
@@ -401,43 +401,106 @@
         }
     },
     "events": {
-        "thingRegistration": {
-            "description": "Thing Description registration events",
-            "uriVariables": {
-                "type": {
-                    "title": "Event type(s)",
-                    "description": "Zero or more event types server-side event filtering",
-                    "type": "string",
-                    "enum": [
-                        "create",
-                        "update",
-                        "delete"
-                    ]
-                },
-                "full": {
-                    "title": "Include TD changes inside event data",
-                    "type": "boolean"
-                }
-            },
-            "forms": [
-                {
-                    "op": "subscribeevent",
-                    "href": "/events{?type,full}",
-                    "subprotocol": "sse",
-                    "contentType": "text/event-stream",
-                    "htv:headers": [
-                        {
-                            "description": "ID of the last event provided by reconnecting clients",
-                            "htv:fieldName": "Last-Event-ID"
-                        }
-                    ],
-                    "data": {
-                        "description": "Partial or complete TD",
-                        "type": "object"
-                    },
-                    "scopes": "notification"
-                }
-            ]
+        "thingCreated": {
+          "@type": "ThingCreatedEvent",
+          "title": "Thing created",
+          "data": {
+              "type": "object",
+              "description": "The schema of created TD event data including the created TD",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td": {
+                      "type": "object",
+                      "description": "The created TD in a create event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingcreated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingUpdated": {
+          "@type:": "ThingUpdatedEvent",
+          "title": "Thing updated",
+          "data": {
+              "type": "object",
+              "description": "The schema of updated TD event data including the TD updates",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  },
+                  "td_updates": {
+                      "type": "object",
+                      "description": "The partial TD composed of modified TD parts in an update event"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingupdated",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+          ]
+        },
+        "thingDeleted": {
+          "@type": "ThingDeletedEvent",
+          "title": "Thing deleted",
+          "data": {
+              "type": "object",
+              "description": "The schema of deleted TD event data",
+              "properties": {
+                  "td_id": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "description": "Identifier of TD in directory"
+                  }
+              }
+          },
+          "forms": [
+              {
+                  "op": "subscribeevent",
+                  "href": "/events/thingdeleted",
+                  "subprotocol": "sse",
+                  "contentType": "text/event-stream",
+                  "htv:headers": [
+                      {
+                          "description": "ID of the last event for reconnection",
+                          "htv:fieldName": "Last-Event-ID",
+                          "htv:fieldValue": ""
+                      }
+                  ],
+                  "scopes": "notifications"
+              }
+           ]
         }
     }
 }

--- a/directory.td.json
+++ b/directory.td.json
@@ -404,8 +404,8 @@
         "thingCreation": {
           "description": "Registration of Thing Descriptions inside the directory",
           "uriVariables": {
-            "full": {
-                "title": "Include TD changes inside event data",
+            "diff": {
+                "description": "Receive the full created TD as event data",
                 "type": "boolean"
             }
           },
@@ -416,7 +416,7 @@
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=create{&full}",
+                  "href": "/events?type=create{&diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
@@ -432,19 +432,20 @@
         "thingUpdate": {
           "description": "Updates to Thing Descriptions within the directory",
           "uriVariables": {
-            "full": {
-                "title": "Include TD changes inside event data",
+            "diff": {
+                "description": "Include TD changes inside event data",
                 "type": "boolean"
             }
           },
           "data": {
             "title": "Partial TD",
-            "type": "object"
+            "type": "object",
+            "contentMediaType": "application/merge-patch+json"
           },
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=update{&full}",
+                  "href": "/events?type=update{&diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -416,7 +416,7 @@
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=create{&diff}",
+                  "href": "/events/create{?diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
@@ -445,7 +445,7 @@
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=update{&diff}",
+                  "href": "/events/update{?diff}",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [
@@ -467,7 +467,7 @@
           "forms": [
               {
                   "op": "subscribeevent",
-                  "href": "/events?type=delete",
+                  "href": "/events/delete",
                   "subprotocol": "sse",
                   "contentType": "text/event-stream",
                   "htv:headers": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -401,8 +401,8 @@
         }
     },
     "events": {
-        "thingCreated": {
-          "title": "Thing created",
+        "thingCreation": {
+          "description": "Registration of Thing Descriptions inside the directory",
           "uriVariables": {
             "full": {
                 "title": "Include TD changes inside event data",
@@ -429,8 +429,8 @@
               }
           ]
         },
-        "thingUpdated": {
-          "title": "Thing updated",
+        "thingUpdate": {
+          "description": "Updates to Thing Descriptions within the directory",
           "uriVariables": {
             "full": {
                 "title": "Include TD changes inside event data",
@@ -457,8 +457,8 @@
               }
           ]
         },
-        "thingDeleted": {
-          "title": "Thing deleted",
+        "thingDeletion": {
+          "description": "Deletion of Thing Descriptions from the directory",
           "data": {
             "title": "Partial TD",
             "type": "object"

--- a/index.html
+++ b/index.html
@@ -1533,28 +1533,6 @@ img.wot-diagram {
                                     At the absence of any `type` query parameter, the server will deliver all
                                     types of events.
                                 </li>
-                                <!-- Commented for now. See the issue details below. -->
-                                <!-- <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-filter-search">
-                                        The server MAY support event filtering based on the 
-                                        search expressions passed as one of `jsonpath`, `xpath`, 
-                                        or `sparql` query parameters.
-                                    </span>
-                                    This is to detect changes on particular TDs or attributes and does not affect
-                                    the event's data object.
-                                    <p>
-                                        For example, the JSONPath expression `$.properties`
-                                        will reduce the number of events to TDs that change their `properties` attributes.
-                                        The resulting events may be for created or deleted TDs with the `properties` attribute
-                                        or updates to `properties` attribute of existing TDs.
-                                    </p>
-                                    <span class="rfc2119-assertion" id="tdd-notification-filter-search-unsupported">
-                                        If the server does not support a given search query parameter, it
-                                        MUST reject the request with 501 (Not Implemented) status.
-                                    </span>
-                                    This is to inform the clients about the missing feature at the connection
-                                    time and prevent unexpected network traffic and events.
-                                </li> -->
                             </ul>
                             <div class="issue" data-number="176">
                                 Event filtering based on the payload is work in progress. 

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,6 @@ img.wot-diagram {
                         In particular, the server responds to successful requests with 200 (OK) status
                         and `text/event-stream` Content Type. Re-connecting clients may continue from
                         the last event by providing the last event ID as `Last-Event-ID` header value.
-                        This API is specified as `thingRegistration` event in [[[#directory-thing-description]]].
                     </p>
 
                     <dl>
@@ -1667,6 +1666,11 @@ img.wot-diagram {
                             </ul>
                         </dd>
                     </dl>
+                    <p>
+                        The Notification API is specified as three event affordances in
+                        [[[#directory-thing-description]]], namely:
+                        `thingCreation`, `thingUpdate`, and `thingDeletion`.
+                    </p>
 
                     <p class="ednote" title="SSE Authorization Header">
                         Some early SSE implementations (including HTML5 EventSource) do not allow

--- a/index.html
+++ b/index.html
@@ -1586,7 +1586,7 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-create-full">
-                                        When `full` query parameter is set to `true` and the event has `create` type,
+                                        When `diff` query parameter is set to `true` and the event has `create` type,
                                         the server MAY return the whole TD object as event data.
                                     </span>
                                     
@@ -1619,12 +1619,12 @@ img.wot-diagram {
                                     </aside>
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full">
-                                        When `full` query parameter is set to `true` and the event has `update` type,
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-update-diff">
+                                        When `diff` query parameter is set to `true` and the event has `update` type,
                                         the server MAY inform the client about the updated parts following the
                                         JSON Merge Patch [[RFC7396]] format.
                                     </span>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full-id">
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-update-id">
                                         An `update` event data that is based on JSON Merge Patch [[RFC7396]]
                                         MUST always include the identifier of the TD regardless of whether it
                                         is changed.
@@ -1646,16 +1646,15 @@ img.wot-diagram {
                                     </p>
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-updates-full">
-                                        The `full` query parameter MUST be ignored for `delete` events.
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-delete-diff">
+                                        The `diff` query parameter MUST be ignored for `delete` events.
                                     </span>
-                                    In other words, when the `full` query parameter is set to `true` and
-                                    the event has `delete` type, the server must only provide the identifier
-                                    in event data.
+                                    In other words, the server does not need to include additional properties in
+                                    the payload of `delete` events when `diff` is set to `true`. 
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-change-unsupported">
-                                        When a server which does not support the `full` query parameter 
+                                    <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported">
+                                        When a server which does not support the `diff` query parameter 
                                         is requested with such query parameter, it MUST
                                         reject the request with 501 (Not Implemented) status.
                                     </span>

--- a/index.html
+++ b/index.html
@@ -1520,20 +1520,31 @@ img.wot-diagram {
                             by delivering only the events required by clients.
                             Client libraries may offer additional filtering capabilities on
                             the client-side.
-                            The server-side filtering is based on query parameters passed to the server at 
-                            connection time. The filtering behavior is described below:
-                            <ul>
-                                <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-filter-type">
-                                        The server MUST support event filtering based on the 
-                                        event types passed as one or more `type` query parameters.
-                                    </span>
-                                    For example, in response to query `?type=create&type=delete`,
-                                    the server will only deliver events of types `create` and `delete`.
-                                    At the absence of any `type` query parameter, the server will deliver all
-                                    types of events.
-                                </li>
-                            </ul>
+
+                            <p>
+                                <span class="rfc2119-assertion" id="tdd-notification-filter-type">
+                                    The server MUST support event filtering based on the 
+                                    event type given by the client upon subscription. 
+                                </span>
+                            </p>
+                            <p>
+                                For example, given the URI Template `/events{/type}`:
+                                <ul>
+                                    <li>
+                                        `/events/create` instructs the server to only deliver events of
+                                        type `create`
+                                    </li>
+                                    <li>
+                                        `/events` instructs the server to deliver all events
+                                    </li>
+                                </ul>
+                                The clients need to subscribe separately to receive a subset of
+                                the events (e.g. only `create` and `delete`) from the server. 
+                                When using HTTP/2, multiple subscriptions on the same domain (HTTP streams) 
+                                get multiplexed on a single connection.
+                            </p>
+
+
                             <div class="issue" data-number="176">
                                 Event filtering based on the payload is work in progress. 
                             </div>


### PR DESCRIPTION
Based on [refactor-3](https://github.com/farshidtz/wot-discovery/tree/refactor-3), from #196. 

This is a change to the API, a part of the proposal in #159.

The splitting of the event affordance from one to three (#196) resulted in a strange-looking API specification. In other words, this PR is mostly a change to make the spec look nicer. 

Functionality-wise, this change will make it harder / less efficient if a client wants to subscribe to a subset of events (more than one, but not all). HTTP/2 multiplexes such subscriptions but the server and clients still need to allocate additional memory to handle concurrent subscriptions. 

Thinking about MQTT as a future extension, this change makes it much easier to have a 1-to-1 mapping. In MQTT, there is no way to subscribe to a subset of events in a single SUB operation. It would be either one (e.g. topic things/create) or all (e.g. topic: things/+). Multiple subscriptions in MQTT share a single connection, similar to SSE over HTTP/2.

In general, I am in favor of this change.

---

The current API:
```
/events{?type,diff}
```
e.g. expansion:
* `/events?type=create&diff=true` one event
* `/events?diff=true` all events

is being changed to:
```
/events{/type}{?diff}
```
e.g. expansion:
* `/events/create?diff=true` one event
* `/events?diff=true` all events


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/198.html" title="Last updated on Jun 7, 2021, 11:23 AM UTC (a602cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/198/89e9932...farshidtz:a602cce.html" title="Last updated on Jun 7, 2021, 11:23 AM UTC (a602cce)">Diff</a>