### PR TITLE
Add missing event IDs in SSE examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1500,8 +1500,13 @@ img.wot-diagram {
                             specifications to serve events to clients. 
                         </span>
                         In particular, the server responds to successful requests with 200 (OK) status
-                        and `text/event-stream` Content Type. Re-connecting clients may continue from
+                        and `text/event-stream` Content Type.
+                        Re-connecting clients may continue from
                         the last event by providing the last event ID as `Last-Event-ID` header value.
+                        <span class="rfc2119-assertion" id="tdd-notification-event-id">
+                            The server SHOULD provide an event ID as the `id` field in each event
+                            and respond to re-connecting clients by delivering all missed events.
+                        </span>
                     </p>
 
                     <dl>

--- a/index.html
+++ b/index.html
@@ -1567,9 +1567,11 @@ img.wot-diagram {
                                         <pre>
                                             event: create
                                             data: {"id": "urn:example:simple-td"}
+                                            id: event_1
 
                                             event: delete
                                             data: {"id": "urn:example:simple-td"}
+                                            id: event_2
                                         </pre>
                                     </aside>
                                 </li>
@@ -1601,6 +1603,7 @@ img.wot-diagram {
                                             data:     },
                                             data:     "title": "Simple TD"
                                             data: }
+                                            id: event_1
                                         </pre>
                                         <div class="issue" data-number="148">
                                             The context URIs are tentative and subject to change.
@@ -1630,6 +1633,7 @@ img.wot-diagram {
                                                 data:     "id": "urn:example:simple-td",
                                                 data:     "title": "Updated TD"
                                                 data: }
+                                                id: event_3
                                             </pre>
                                         </aside>
                                     </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/205.html" title="Last updated on Jun 14, 2021, 1:47 PM UTC (40fb2c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/205/d172eb8...farshidtz:40fb2c0.html" title="Last updated on Jun 14, 2021, 1:47 PM UTC (40fb2c0)">Diff</a>