### PR TITLE
Add alternative payload format (2)

### DIFF
--- a/context/discovery-context.jsonld
+++ b/context/discovery-context.jsonld
@@ -9,7 +9,17 @@
       "@id": "discovery:ThingLink",
       "@type": "@id"
     },
-    "registration": {
+	"ThingCollection": {
+      "@id": "discovery:ThingCollection",
+      "@type": "@id"
+    },
+	"totalItems": "discovery:contains",
+	"member": [
+	  "@graph"
+	],
+	"@id": "discovery:thisThingCollection",
+	"next": "discovery:nextThingCollection",
+	"registration": {
       "@id": "discovery:hasRegistrationInformation",
       "@type": "@id",
       "@context": {

--- a/context/discovery-context.jsonld
+++ b/context/discovery-context.jsonld
@@ -13,8 +13,8 @@
       "@id": "discovery:ThingCollection",
       "@type": "@id"
     },
-	"totalItems": "discovery:contains",
-	"member": [
+	"total": "discovery:contains",
+	"members": [
 	  "@graph"
 	],
 	"@id": "discovery:thisThingCollection",

--- a/context/discovery-context.jsonld
+++ b/context/discovery-context.jsonld
@@ -15,7 +15,7 @@
     },
 	"total": "discovery:contains",
 	"members": [
-	  "@graph"
+	  "td:Thing"
 	],
 	"@id": "discovery:thisThingCollection",
 	"next": "discovery:nextThingCollection",

--- a/directory.td.json
+++ b/directory.td.json
@@ -71,6 +71,12 @@
                     "title": "Number of TDs in a page",
                     "type": "number"
                 },
+                "format": {
+                    "title": "Payload format",
+                    "type": "string",
+                    "enum": ["array", "hydraCollection"],
+                    "default": "array"
+                },
                 "sort_by": {
                     "title": "Comparator TD attribute for collection sorting",
                     "type": "string",

--- a/directory.td.json
+++ b/directory.td.json
@@ -74,7 +74,7 @@
                 "format": {
                     "title": "Payload format",
                     "type": "string",
-                    "enum": ["array", "hydraCollection"],
+                    "enum": ["array", "collection"],
                     "default": "array"
                 },
                 "sort_by": {

--- a/index.html
+++ b/index.html
@@ -1404,44 +1404,35 @@ img.wot-diagram {
 						<p>
 							For pagination information the alternative format leans against the formats as described
 							in <a href="https://www.hydra-cg.com/spec/latest/core/#advanced-concepts">
-							Hydra Advanced Concepts</a>. More concretely the
+							Hydra Advanced Concepts</a>, more concretely the
 							<a href="https://www.hydra-cg.com/spec/latest/core/#example-20-a-hydra-partialcollectionview-splits-a-collection-into-multiple-views">
-							Partial Collection View</a> using the <i>members</i> field to accomodate the array
-							of TDs is applied, and looks like as follows for the listing endpoint:
+							Partial Collection View</a>. Adapted to our purposes and using the <i>member</i> field to accomodate the array
+							of TDs, it looks like as follows for the listing endpoint:
 						</p>
 						<p>
 							<aside class="example" id="example-alternative-payload"
 								title="Alternative payload format including pagination information">
 								<pre>
 									{
-										"@context": "http://www.w3.org/ns/hydra/context.jsonld",
-										"@type": "Collection",
+										"@context": "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld",
+										"@type": "ThingCollection",
 										"totalItems": 12,
 										"member": [
 											{ TD },
 											9 other TDs...
 										],
-										"view": {
-											"@type":"PartialCollectionView",
-											"@id": "/things?offset=0&limit=10&format=hydraCollection",
-											"next": "/things?offset=10&limit=10&format=hydraCollection"
-										}
+										"@id": "/things?offset=0&limit=10&format=collection",
+										"next": "/things?offset=10&limit=10&format=collection"
 									}
 								</pre>                    
 							</aside>
 						</p>
 						
 						<p>
-							To tell the server which format to send, the additional query parameter <i>?format=array|hydraCollection</i>
-							can be added to the request. <i>?format=array</i> is the default parameter, does not have to be provided
-							explicitly, and yields to a server response of the pure array of TDs. <i>?format=hydraCollection</i>
+							To tell the server which format to send, the additional query parameter <code>?format=array|collection</code>
+							can be added to the request. <code>?format=array</code> is the default parameter, does not have to be provided
+							explicitly, and yields to a server response of the pure array of TDs. <code>?format=collection</code>
 							should yield to a server response with the format as described in [[[#example-alternative-payload]]].
-						</p>
-						
-						<p>
-							Having the additional query parameter in place along with the references
-							to external ontologies inside the alternative payload, opens the listing interface
-							for yet more payload formats to be described in upcoming specifications.
 						</p>
 						
                         <p>

--- a/index.html
+++ b/index.html
@@ -1266,76 +1266,6 @@ img.wot-diagram {
                                 Content-Type header, and an array of TDs in the body.
                             </span>
 
-							<p>
-								Alternative to a pure array of TDs as the body of the response, the server MAY
-								send a more verbose payload allowing server-side information, like pagination
-								information, to be put in addition to the actual data.
-							</p>
-								
-							<p>
-								For pagination information the alternative format leans against the formats as described
-								in <a href="https://www.hydra-cg.com/spec/latest/core/#advanced-concepts">
-								Hydra Advanced Concepts</a>. More concretely the
-								<a href="https://www.hydra-cg.com/spec/latest/core/#example-20-a-hydra-partialcollectionview-splits-a-collection-into-multiple-views">
-								Partial Collection View</a> using the <i>members</i> field to accomodate the array
-								of TDs is applied, and looks like as follows for the listing endpoint:
-							</p>
-							<p>
-								<aside class="example" id="example-alternative-payload"
-									title="Alternative payload format including pagination information">
-									<pre>
-										{
-											"@context": "http://www.w3.org/ns/hydra/context.jsonld",
-											"@type": "Collection",
-											"totalItems": 10,
-											"member": [
-												{ TD },
-												9 other TDs...
-											],
-											"view": {
-												"@type":"PartialCollectionView",
-												"@id": "/td?offset=0&limit=10",
-												"next": "/td?offset=1&limit=10"
-											}
-										}
-									</pre>                    
-								</aside>
-							</p>
-							
-							<p>
-								To tell the server which format to send, the additional query parameter <i>?format=array|hydraCollection</i>
-								can be added to the request. <i>?format=array</i> is the default parameter, does not have to be provided
-								explicitly, and yields to a server response of the pure array of TDs. <i>?format=hydraCollection</i>
-								should yield to a server response with the format as described in [[[#example-alternative-payload]]].
-							</p>
-							
-							<p>
-								Having the additional query parameter in place along with the references
-								to external ontologies inside the alternative payload, opens the listing interface
-								for yet more payload formats to be described in upcoming specifications.
-							</p>
-							
-                        </p>
-
-                        <p>
-                            Serializing and returning the full list of TDs may be burdensome to servers.
-                            As such, servers should serialize incrementally and utilize protocol-specific
-                            mechanisms to respond in chunks. 
-                            <span class="rfc2119-assertion" id="tdd-reg-list-http11-chunks">
-                                HTTP/1.1 servers SHOULD perform chunked 
-                                <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">Transfer-Encoding</a> [[RFC7230]]
-                                to respond the data incrementally.
-                            </span>
-                            Most HTTP/1.1 clients automatically process the data received with 
-                            chunked transfer encoding.
-                            Memory-constrained applications which require the full list
-                            should consider processing the received data incrementally.
-
-                            Chunked transfer encoding is not supported in HTTP/2.
-                            <span class="rfc2119-assertion" id="tdd-reg-list-http2-frames">
-                                HTTP/2 servers SHOULD respond the data incrementally using 
-                                <a href="https://tools.ietf.org/html/rfc7540#section-4">HTTP Frames</a> [[RFC7540]].
-                            </span>
                         </p>
 
                         <p>
@@ -1463,6 +1393,76 @@ img.wot-diagram {
                                 because this is the last page. The `etag` value has not changed implying
                                 that the collection has remained consistent between the two requests.
                             </aside>
+                        </p>
+
+						<p>
+							Alternative to a pure array of TDs as the body of the response, the server MAY
+							send a more verbose payload allowing server-side information, like pagination
+							information, to be put in addition to the actual data.
+						</p>
+							
+						<p>
+							For pagination information the alternative format leans against the formats as described
+							in <a href="https://www.hydra-cg.com/spec/latest/core/#advanced-concepts">
+							Hydra Advanced Concepts</a>. More concretely the
+							<a href="https://www.hydra-cg.com/spec/latest/core/#example-20-a-hydra-partialcollectionview-splits-a-collection-into-multiple-views">
+							Partial Collection View</a> using the <i>members</i> field to accomodate the array
+							of TDs is applied, and looks like as follows for the listing endpoint:
+						</p>
+						<p>
+							<aside class="example" id="example-alternative-payload"
+								title="Alternative payload format including pagination information">
+								<pre>
+									{
+										"@context": "http://www.w3.org/ns/hydra/context.jsonld",
+										"@type": "Collection",
+										"totalItems": 12,
+										"member": [
+											{ TD },
+											9 other TDs...
+										],
+										"view": {
+											"@type":"PartialCollectionView",
+											"@id": "/things?offset=0&limit=10&format=hydraCollection",
+											"next": "/things?offset=10&limit=10&format=hydraCollection"
+										}
+									}
+								</pre>                    
+							</aside>
+						</p>
+						
+						<p>
+							To tell the server which format to send, the additional query parameter <i>?format=array|hydraCollection</i>
+							can be added to the request. <i>?format=array</i> is the default parameter, does not have to be provided
+							explicitly, and yields to a server response of the pure array of TDs. <i>?format=hydraCollection</i>
+							should yield to a server response with the format as described in [[[#example-alternative-payload]]].
+						</p>
+						
+						<p>
+							Having the additional query parameter in place along with the references
+							to external ontologies inside the alternative payload, opens the listing interface
+							for yet more payload formats to be described in upcoming specifications.
+						</p>
+						
+                        <p>
+                            Serializing and returning the full list of TDs may be burdensome to servers.
+                            As such, servers should serialize incrementally and utilize protocol-specific
+                            mechanisms to respond in chunks. 
+                            <span class="rfc2119-assertion" id="tdd-reg-list-http11-chunks">
+                                HTTP/1.1 servers SHOULD perform chunked 
+                                <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">Transfer-Encoding</a> [[RFC7230]]
+                                to respond the data incrementally.
+                            </span>
+                            Most HTTP/1.1 clients automatically process the data received with 
+                            chunked transfer encoding.
+                            Memory-constrained applications which require the full list
+                            should consider processing the received data incrementally.
+
+                            Chunked transfer encoding is not supported in HTTP/2.
+                            <span class="rfc2119-assertion" id="tdd-reg-list-http2-frames">
+                                HTTP/2 servers SHOULD respond the data incrementally using 
+                                <a href="https://tools.ietf.org/html/rfc7540#section-4">HTTP Frames</a> [[RFC7540]].
+                            </span>
                         </p>
 
                         <p>    

--- a/index.html
+++ b/index.html
@@ -1265,6 +1265,56 @@ img.wot-diagram {
                                 A successful response MUST have 200 (OK) status, contain `application/ld+json`
                                 Content-Type header, and an array of TDs in the body.
                             </span>
+
+							<p>
+								Alternative to a pure array of TDs as the body of the response, the server MAY
+								send a more verbose payload allowing server-side information, like pagination
+								information, to be put in addition to the actual data.
+							</p>
+								
+							<p>
+								For pagination information the alternative format leans against the formats as described
+								in <a href="https://www.hydra-cg.com/spec/latest/core/#advanced-concepts">
+								Hydra Advanced Concepts</a>. More concretely the
+								<a href="https://www.hydra-cg.com/spec/latest/core/#example-20-a-hydra-partialcollectionview-splits-a-collection-into-multiple-views">
+								Partial Collection View</a> using the <i>members</i> field to accomodate the array
+								of TDs is applied, and looks like as follows for the listing endpoint:
+							</p>
+							<p>
+								<aside class="example" id="example-alternative-payload"
+									title="Alternative payload format including pagination information">
+									<pre>
+										{
+											"@context": "http://www.w3.org/ns/hydra/context.jsonld",
+											"@type": "Collection",
+											"totalItems": 10,
+											"member": [
+												{ TD },
+												9 other TDs...
+											],
+											"view": {
+												"@type":"PartialCollectionView",
+												"@id": "/td?offset=0&limit=10",
+												"next": "/td?offset=1&limit=10"
+											}
+										}
+									</pre>                    
+								</aside>
+							</p>
+							
+							<p>
+								To tell the server which format to send, the additional query parameter <i>?format=array|hydraCollection</i>
+								can be added to the request. <i>?format=array</i> is the default parameter, does not have to be provided
+								explicitly, and yields to a server response of the pure array of TDs. <i>?format=hydraCollection</i>
+								should yield to a server response with the format as described in [[[#example-alternative-payload]]].
+							</p>
+							
+							<p>
+								Having the additional query parameter in place along with the references
+								to external ontologies inside the alternative payload, opens the listing interface
+								for yet more payload formats to be described in upcoming specifications.
+							</p>
+							
                         </p>
 
                         <p>

--- a/index.html
+++ b/index.html
@@ -1406,7 +1406,7 @@ img.wot-diagram {
 							in <a href="https://www.hydra-cg.com/spec/latest/core/#advanced-concepts">
 							Hydra Advanced Concepts</a>, more concretely the
 							<a href="https://www.hydra-cg.com/spec/latest/core/#example-20-a-hydra-partialcollectionview-splits-a-collection-into-multiple-views">
-							Partial Collection View</a>. Adapted to our purposes and using the <i>member</i> field to accomodate the array
+							Partial Collection View</a>. Adapted to our purposes and using the <i>members</i> field to accomodate the array
 							of TDs, it looks like as follows for the listing endpoint:
 						</p>
 						<p>
@@ -1416,8 +1416,8 @@ img.wot-diagram {
 									{
 										"@context": "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld",
 										"@type": "ThingCollection",
-										"totalItems": 12,
-										"member": [
+										"total: 12,
+										"members": [
 											{ TD },
 											9 other TDs...
 										],


### PR DESCRIPTION
Rework of https://github.com/w3c/wot-discovery/pull/168

resolves #16


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wiresio/wot-discovery/pull/213.html" title="Last updated on Jul 26, 2021, 3:52 PM UTC (034d81f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/213/6f0f355...wiresio:034d81f.html" title="Last updated on Jul 26, 2021, 3:52 PM UTC (034d81f)">Diff</a>