### PR TITLE
Add Well-Known URI and Service Name in "IANA Considerations" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2173,8 +2173,8 @@ be discussed elsewhere and perhaps mentioned as tools for addressing the followi
                 <li>URI suffix: <code>wot-thing-description</code></li>
             </ul>
             <p class="ednote" title="Shorter suffix">
-                We are currently disucissing whether we should adopt a shorter URI suffix (such as <code>wot-td</code>)
-                in view of the limited packet length.
+                We are currently discussing whether we should adopt a shorter URI suffix (such as <code>wot-td</code>)
+                in view of limited packet lengths for some protocols.
             </p>
         </section>
         <section id="service-name">

--- a/index.html
+++ b/index.html
@@ -2163,6 +2163,34 @@ be discussed elsewhere and perhaps mentioned as tools for addressing the followi
 
     <section id="iana-considerations" class="normative">
         <h1>IANA Considerations</h1>
+        <section id="well-known-uri-suffix">
+            <h2>Well-Known URI Registration</h2>
+            <p>
+                IANA will be asked to allocate the following value into the Well-Known URI
+                defined in [[RFC8615]].
+            </p>
+            <ul>
+                <li>URI suffix: <code>wot-thing-description</code></li>
+            </ul>
+            <p class="ednote" title="Shorter suffix">
+                We are currently disucissing whether we should adopt a shorter URI suffix (such as <code>wot-td</code>)
+                in view of the limited packet length.
+            </p>
+        </section>
+        <section id="service-name">
+            <h2>Service Name Registration</h2>
+            <p>
+                IANA will be asked to allocate the following value into Service Name and Transport Protocol Port Number Registry
+                defined in [[RFC6335]].
+            </p>
+            <ul>
+                <li>Service Name: <code>wot</code></li>
+                <li>Transport Protocol: TCP, UDP</li>
+                <li>Description: Service name to search a Thing or a Thing Description Directory of W3C Web of Things</li>
+                <li>Port Number: N/A</li>
+                <li>Assignment notes: PTR, SRV, TXT RR types are used</li>
+            </ul>
+        </section>
         <section id="core-resource-type">
             <h2>CoRE Resource Types Registration</h2>
             <p>


### PR DESCRIPTION
Add following information to "9. IANA Considerations".
- Well-known URI: `wot-thing-description`
- Service Name: `wot`

(related issue: #187)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-discovery/pull/217.html" title="Last updated on Aug 30, 2021, 2:40 PM UTC (ff81a98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/217/a64f17c...k-toumura:ff81a98.html" title="Last updated on Aug 30, 2021, 2:40 PM UTC (ff81a98)">Diff</a>