### PR TITLE
HTTP HEAD method to request the content length

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,19 +859,20 @@ img.wot-diagram {
                     </span>
                     This enables both machines and humans to know the high-level error class
                     and fine-grained details.
-
-                    <p class="ednote" title="WoT-specific error types">
-                        The Problem Details error `type` field is a URI reference which 
-                        could used to map the occurred error to WoT-specific error class. 
-                        There are few open issues raising the lack of WoT-specific error types:
-                        <a href="https://github.com/w3c/wot-discovery/issues/44">wot-discovery#44</a>,
-                        <a href="https://github.com/w3c/wot-thing-description/issues/303">wot-thing-description#303</a>,
-                        <a href="https://github.com/w3c/wot-scripting-api/issues/200">wot-scripting-api#200</a>.
-                        <br>
-                        For now, `type` can be omitted which defaults to "about:blank", and `title`
-                        should be set to HTTP status text.
-                    </p>
                 </p>
+
+                <p class="ednote" title="WoT-specific error types">
+                    The Problem Details error `type` field is a URI reference which 
+                    could used to map the occurred error to WoT-specific error class. 
+                    There are few open issues raising the lack of WoT-specific error types:
+                    <a href="https://github.com/w3c/wot-discovery/issues/44">wot-discovery#44</a>,
+                    <a href="https://github.com/w3c/wot-thing-description/issues/303">wot-thing-description#303</a>,
+                    <a href="https://github.com/w3c/wot-scripting-api/issues/200">wot-scripting-api#200</a>.
+                    <br>
+                    For now, `type` can be omitted which defaults to "about:blank", and `title`
+                    should be set to HTTP status text.
+                </p>
+                
 
                 <section id="exploration-directory-api-registration" class="normative">
                     <h4>Registration</h4>

--- a/index.html
+++ b/index.html
@@ -873,6 +873,16 @@ img.wot-diagram {
                     should be set to HTTP status text.
                 </p>
                 
+                <p>
+                    <span class="rfc2119-assertion" id="tdd-http-head"> 
+                        For each HTTP endpoint that responds to the `GET` method, the server SHOULD accept `HEAD` 
+                        requests and return only the headers.
+                    </span>
+                    This allows clients to retrieve headers such as the Content-Length without receiving the body
+                    and decide on a suitable strategy to query the information. For example, a constrained client can
+                    request only the necessary parts of an object (using an apprpriate search query) or 
+                    retrieve a list of items in small subsets.
+                </p>
 
                 <section id="exploration-directory-api-registration" class="normative">
                     <h4>Registration</h4>

--- a/index.html
+++ b/index.html
@@ -875,7 +875,7 @@ img.wot-diagram {
                 
                 <p>
                     <span class="rfc2119-assertion" id="tdd-http-head"> 
-                        For each HTTP endpoint that responds to the `GET` method, the server SHOULD accept `HEAD` 
+                        For each HTTP endpoint that responds to the `GET` method, the server MUST accept `HEAD` 
                         requests and return only the headers.
                     </span>
                     This allows clients to retrieve headers such as the Content-Length without receiving the body


### PR DESCRIPTION
Related to https://github.com/w3c/wot-discovery/issues/146


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/218.html" title="Last updated on Aug 30, 2021, 2:50 PM UTC (e7ce505)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/218/57e3dbe...farshidtz:e7ce505.html" title="Last updated on Aug 30, 2021, 2:50 PM UTC (e7ce505)">Diff</a>