### PR TITLE
HTTP HEAD method to request the content length (self-description)

### DIFF
--- a/index.html
+++ b/index.html
@@ -647,7 +647,7 @@ img.wot-diagram {
                         </span>
                     </p>
                     <p>
-                        <span class="rfc2119-assertion" id="self-http-alternate-content">
+                        <span class="rfc2119-assertion" id="self-http-head">
                             The HTTP server SHOULD respond to `HEAD` requests by returning only the headers
                             equivalent to those returned by a `GET` request to the same endpoint.
                         </span>

--- a/index.html
+++ b/index.html
@@ -613,7 +613,7 @@ img.wot-diagram {
                 through others means. 
                 If exposed at a URL (e.g. over HTTP or CoAP), the URL may be advertised
                 via one of the [[[#introduction-mech]]].
-                The hosted TD may also be registered inside a <a>Thing Description Directory</a>
+                The hosted <a>TD</a> may also be registered inside a <a>Thing Description Directory</a>
                 as prescribed in [[[#exploration-directory]]]. 
             </p>
             
@@ -626,22 +626,24 @@ img.wot-diagram {
                         <span class="rfc2119-assertion" id="self-http-secure"> 
                             The HTTP-based self-description SHOULD be over HTTPS (HTTP Over TLS).
                         </span>
+                        <span class="rfc2119-assertion" id="self-http-access-control">
+                            The server SHOULD serve the requests after performing necessary 
+                            authentication and authorization.
+                        </span>
+                    </p>
+                    <p>
                         <span class="rfc2119-assertion" id="self-http-method"> 
-                            The HTTP server MUST serve the TD with a `GET` method.
+                            The HTTP server MUST serve the <a>TD</a> with a `GET` method.
                         </span>
                         <span class="rfc2119-assertion" id="self-http-resp">
                             A successful response MUST have 200 (OK) status, contain `application/td+json`
-                            Content-Type header, and the TD in body.
+                            Content-Type header, and the <a>TD</a> in body.
                         </span>
                         <span class="rfc2119-assertion" id="self-http-alternate-content">
                             The server MAY provide alternative representations through
                             server-driven content negotiation, that is by honouring the 
                             request's Accept header and responding with the supported
                             TD serialization and equivalent Content-Type header.
-                        </span>
-                        <span class="rfc2119-assertion" id="self-http-access-control">
-                            The server SHOULD serve the requests after performing necessary 
-                            authentication and authorization.
                         </span>
                     </p>
                     

--- a/index.html
+++ b/index.html
@@ -646,6 +646,14 @@ img.wot-diagram {
                             TD serialization and equivalent Content-Type header.
                         </span>
                     </p>
+                    <p>
+                        <span class="rfc2119-assertion" id="self-http-alternate-content">
+                            The HTTP server SHOULD respond to `HEAD` requests by returning only the headers
+                            equivalent to those returned by a `GET` request to the same endpoint.
+                        </span>
+                        This enables clients to retrieve HTTP headers such as the Content-Length in advance 
+                        to know the size of the <a>TD</a> (in bytes) and decide on an efficient query strategy.
+                    </p>
                     
                     <p>
                         Error responses:  

--- a/index.html
+++ b/index.html
@@ -648,7 +648,7 @@ img.wot-diagram {
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="self-http-head">
-                            The HTTP server SHOULD respond to `HEAD` requests by returning only the headers
+                            The HTTP server MUST respond to `HEAD` requests by returning only the headers
                             equivalent to those returned by a `GET` request to the same endpoint.
                         </span>
                         This enables clients to retrieve HTTP headers such as the Content-Length in advance 


### PR DESCRIPTION
Together with PR #218, this resolves #146.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/219.html" title="Last updated on Aug 30, 2021, 2:56 PM UTC (9105134)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/219/57e3dbe...farshidtz:9105134.html" title="Last updated on Aug 30, 2021, 2:56 PM UTC (9105134)">Diff</a>