### PR TITLE
Fix assertion in section 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,11 +309,12 @@ img.wot-diagram {
         <p>This chapter describes a mechanism for discovering a Thing or a <a>Thing Description Directory</a>.
            The following mechanism is provided by the Thing or the <a>Thing Description Directory</a> so that
            Consumers can discover the Thing Description or a URL that point to the Thing Description.
+           No paticular introduction mechanism is mandatory, as long as a URL of an exploration service is somehow obtained.
         </p>
 
         <section id="introduction-direct" class="normative">
             <h2>Direct</h2>
-            <p>Any mechanism that results in a single URL.
+            <p><span class="rfc2119-assertion" id="introduction-direct-url">To obtain an URL of an exploration service, any mechanism that results in a single URL MAY be used.</span>
                This includes Bluetooth beacons, QR codes, and written URLs to be 
                typed by a user.
                 <span class="rfc2119-assertion" id="introduction-direct-thing-description">
@@ -330,12 +331,13 @@ img.wot-diagram {
         <section id="introduction-well-known" class="normative">
             <h2>Well-Known URIs</h2>
             <p>
-                A Thing or <a>Thing Description Directory</a> may use the Well-Known Uniform Resource Identifier [[RFC8615]]
-                to advertise its presence.  The Thing or <a>Thing Description Directory</a> registers its own Thing or Directory Description
+                <span class="rfc2119-assertion" id="introduction-well-known-uri">A Thing or <a>Thing Description Directory</a> MAY use the Well-Known Uniform Resource Identifier [[RFC8615]]
+                to advertise its presence.</span>
+                <span class="rfc2119-assertion" id="introduction-well-known-path">If the Thing or <a>Thing Description Directory</a> use the Well-Known Uniform Resource Identifier to advertise its presense, it MUST register its own Thing or Directory Description
                 into the following path:
-                <code>/.well-known/wot-thing-description</code>.
+                <code>/.well-known/wot-thing-description</code>.</span>
             <p>
-                <span class="rfc2119-assertion" id="introduction-well-known-path">
+                <span class="rfc2119-assertion" id="introduction-well-known-thing-description">
                     When a request is made at the above Well-Known URI, the server MUST return
                     a Thing Description as prescribed in [[[#exploration-self]]].
                 </span>
@@ -348,7 +350,7 @@ img.wot-diagram {
         </section>
         <section id="introduction-dns-sd" class="normative">
             <h2>DNS-Based Service Discovery</h2>
-            <p>A Thing or <a>Thing Description Directory</a> may use the DNS-Based Service Discovery (DNS-SD)[[RFC6763]].
+            <p><span class="rfc2119-assertion" id="introduction-dns-sd">A Thing or <a>Thing Description Directory</a> MAY use the DNS-Based Service Discovery (DNS-SD)[[RFC6763]].</span>
                 This can be also be used to discover them on the same link by combining Multicast DNS (mDNS)[[RFC6762]].
             </p>
             <p>
@@ -426,10 +428,11 @@ img.wot-diagram {
         <section id="introduction-core-rd" class="normative">
             <h2>CoRE Link Format and CoRE Resource Directory</h2>
             <p>
-                A Thing or <a>Thing Description Directory</a> may advertise its presence using the
-                Constrained RESTful Environment (CoRE) Link Format [[RFC6690]].
-                And, a Thing or <a>Thing Description Directory</a> may use the CoRE Resource Directory [[CoRE-RD]]
-                to register a link to the Thing or Directory Description.
+                <span class="rfc2119-assertion" id="introduction-core-rd">A Thing or <a>Thing Description Directory</a> MAY advertise its presence using the
+                Constrained RESTful Environment (CoRE) Link Format [[RFC6690]].</span>
+                <span class="rfc2119-assertion" id="introduction-core-rd-directory">
+                A Thing or <a>Thing Description Directory</a> MAY use the CoRE Resource Directory [[CoRE-RD]]
+                to register a link to the Thing or Directory Description.</span>
             </p>
             <p>
                 <span class="rfc2119-assertion" id="introduction-core-rd-resource-type-thing">
@@ -448,8 +451,8 @@ img.wot-diagram {
         </section>
         <section id="introduction-did" class="normative">
             <h2>DID Documents</h2>
-            <p>A Thing or <a>Thing Description Directory</a> may advertise its presence using 
-                the Decentralized Identifier (DID) [[DID-CORE]].
+            <p><span class="rfc2119-assertion" id="introduction-did">A Thing or <a>Thing Description Directory</a> MAY advertise its presence using 
+                the Decentralized Identifier (DID) [[DID-CORE]].</span>
             </p>
             <p>
                 <span class="rfc2119-assertion" id="introduction-did-service-endpoint">


### PR DESCRIPTION
-  Turned back first sentence in the introductions into assertions. (#193)
-  Clarify that no introduction mechanism is mandatory in first paragraph of Section 5 (#200)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-discovery/pull/220.html" title="Last updated on Sep 20, 2021, 6:01 AM UTC (1f44054)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/220/dad5c4f...k-toumura:1f44054.html" title="Last updated on Sep 20, 2021, 6:01 AM UTC (1f44054)">Diff</a>