### PR TITLE
Update intro to introduction mechanisms

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,9 +306,15 @@ img.wot-diagram {
     </section>
     <section id="introduction-mech" class="normative">
         <h1>Introduction Mechanisms</h1>
-        <p>This chapter describes a mechanism for discovering a Thing or a <a>Thing Description Directory</a>.
-           The following mechanism is provided by the Thing or the <a>Thing Description Directory</a> so that
-           Consumers can discover the Thing Description or a URL that point to the Thing Description.
+        <p>This chapter describes mechanisms for initial contact with
+           Things or <a>Thing Description Directories</a>.
+           Any of the following mechanisms may 
+           be provided by the Thing or the <a>Thing Description Directory</a> to Consumers.
+           The result of an introduction mechanism is always a URL (address) of an exploration service
+           which can be used to obtain detailed metadata (TDs) after suitable authentication.
+           It is also possible for multiple introduction mechanisms to be used and the results merged.
+           No particular introduction mechanism is mandatory, as long as the URL of at least one
+           exploration service is somehow obtained.
         </p>
 
         <section id="introduction-direct" class="normative">


### PR DESCRIPTION
Clean up intro to introduction mechanisms, to make clear that:
- Any of the introduction mechanisms can be used
- Multiple introduction mechanisms can be used
- No particular introduction mechanism is mandatory
- The purpose is first contact
- The result is always a URL (NOT TDs or other metadata)
- There might be more than one result and if so they should be used (so in general the result of the introduction process is a SET of URLs pointing to exploration mechanisms).

We might have to clean up some of the text, in particular if it says anywhere an introduction returns a TD.  The result should always be a URL, full stop.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/221.html" title="Last updated on Sep 20, 2021, 2:20 PM UTC (58565d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/221/ef9288b...mmccool:58565d8.html" title="Last updated on Sep 20, 2021, 2:20 PM UTC (58565d8)">Diff</a>