### PR TITLE
Add object types to actions

### DIFF
--- a/directory.td.json
+++ b/directory.td.json
@@ -137,6 +137,7 @@
                 }
             },
             "input": {
+                "description": "The schema is implied by the content type",
                 "type": "object"
             },
             "forms": [
@@ -162,6 +163,7 @@
         "createAnonymousThing": {
             "description": "Create an anonymous Thing Description",
             "input": {
+                "description": "The schema is implied by the content type",
                 "type": "object"
             },
             "forms": [
@@ -201,6 +203,7 @@
                 }
             },
             "output": {
+                "description": "The schema is implied by the content type",
                 "type": "object"
             },
             "safe": true,
@@ -236,6 +239,7 @@
                 }
             },
             "input": {
+                "description": "The schema is implied by the content type",
                 "type": "object"
             },
             "forms": [
@@ -269,6 +273,7 @@
                 }
             },
             "input": {
+                "description": "The schema is implied by the content type",
                 "type": "object"
             },
             "forms": [
@@ -334,6 +339,7 @@
                 }
             },
             "output": {
+                "description": "The schema depends on the given query",
                 "type": "object"
             },
             "safe": true,
@@ -367,6 +373,7 @@
                 }
             },
             "output": {
+                "description": "The schema depends on the given query",
                 "type": "object"
             },
             "safe": true,
@@ -400,6 +407,7 @@
                 }
             },
             "output": {
+                "description": "The schema depends on the given query",
                 "type": "object"
             },
             "safe": true,
@@ -410,6 +418,7 @@
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",
+                        "contentType": "application/json",
                         "htv:statusCodeValue": 200
                     },
                     "additionalResponses": [

--- a/directory.td.json
+++ b/directory.td.json
@@ -136,6 +136,9 @@
                     "format": "iri-reference"
                 }
             },
+            "input": {
+                "type": "object"
+            },
             "forms": [
                 {
                     "href": "/things/{id}",
@@ -158,6 +161,9 @@
         },
         "createAnonymousThing": {
             "description": "Create an anonymous Thing Description",
+            "input": {
+                "type": "object"
+            },
             "forms": [
                 {
                     "href": "/things",
@@ -194,6 +200,9 @@
                     "format": "iri-reference"
                 }
             },
+            "output": {
+                "type": "object"
+            },
             "safe": true,
             "idempotent": true,
             "forms": [
@@ -226,6 +235,9 @@
                     "format": "iri-reference"
                 }
             },
+            "input": {
+                "type": "object"
+            },
             "forms": [
                 {
                     "href": "/things/{id}",
@@ -255,6 +267,9 @@
                     "type": "string",
                     "format": "iri-reference"
                 }
+            },
+            "input": {
+                "type": "object"
             },
             "forms": [
                 {

--- a/directory.td.json
+++ b/directory.td.json
@@ -333,6 +333,9 @@
                     "type": "string"
                 }
             },
+            "output": {
+                "type": "object"
+            },
             "safe": true,
             "idempotent": true,
             "forms": [
@@ -363,6 +366,9 @@
                     "type": "string"
                 }
             },
+            "output": {
+                "type": "object"
+            },
             "safe": true,
             "idempotent": true,
             "forms": [
@@ -392,6 +398,9 @@
                     "title": "A valid SPARQL 1.1. query",
                     "type": "string"
                 }
+            },
+            "output": {
+                "type": "object"
             },
             "safe": true,
             "idempotent": true,


### PR DESCRIPTION
Closes #182

I also added object types for search actions. But we need to clarify JSONPath and XPath models later on: https://github.com/w3c/wot-discovery/issues/156


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/223.html" title="Last updated on Oct 1, 2021, 3:08 PM UTC (d5a3099)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/223/dad5c4f...farshidtz:d5a3099.html" title="Last updated on Oct 1, 2021, 3:08 PM UTC (d5a3099)">Diff</a>