### PR TITLE
Changes to make jsonpath informative

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,17 +82,15 @@
                 , publisher: "IETF"
                 , date: "2 November 2020"
             },
-            "JSONPATH" : {
-                  title: "JavaScript Object Notation (JSON) Path"
-                , href: "https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-00"
+            "JSONPATH": {
+                title: "JSONPath: Query expressions for JSON"
+                , href: "https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base"
                 , authors: [
-                    "Glyn Normington"
-                  , "Edward Surov"
-                  , "Marko Mikulicic"
-                  , "Stefan Gössner"
-                  ]
+                    "Stefan Gössner"
+                    , "Glyn Normington"
+                    , "Carsten Bormann"
+                ]
                 , publisher: "IETF"
-                , date: "7 March 2021"
                 , status: "DRAFT",
             },
             "wot-usecases" : {
@@ -1799,32 +1797,44 @@ img.wot-diagram {
                         To discuss further:
                         Federated queries to other TDDs, Spatial and network-limited queries, Links
                     </p>
-                    The Directory has three search APIs: syntactic search with JSONPath [[?JSONPATH]]
-                    or XPath [[xpath-31]], and semantic search with SPARQL [[sparql11-overview]].
-                    <span class="rfc2119-assertion" id="tdd-search-jsonpath">
+                    This specification describes three search APIs: syntactic search with JSONPath [[?JSONPATH]],
+                    syntactic search with XPath [[xpath-31]], and semantic search with SPARQL [[sparql11-overview]].
+                    <!-- <span class="rfc2119-assertion" id="tdd-search-jsonpath">
                         The Directory MUST implement the syntactic search with JSONPath.
-                    </span>
+                    </span> -->
                     <span class="rfc2119-assertion" id="tdd-search-xpath">
-                        The Directory SHOULD implement the syntactic search with XPath.
+                        The Directory MAY implement the syntactic search with XPath.
                     </span>
                     <span class="rfc2119-assertion" id="tdd-search-sparql">
                         The Directory MAY implement semantic search with SPARQL.
                     </span>
-    		
-                    <section id="jsonpath-semantic" class="normative">
+                    <span class="rfc2119-assertion" id="tdd-search-large-tdds">
+                        It is RECOMMENDED that directories implement at least one search API
+                        to efficiently serve <a>TDs</a> based on client-specific queries.
+                    </span>
+
+                    <section id="jsonpath-semantic" class="informative">
                         <h4>Syntactic search: JSONPath</h4>
-                        <span class="rfc2119-assertion" id="tdd-search-jsonpath-method">
-                            The JSONPath API MUST allow searching TDs using an HTTP <code>GET</code> request
-                            at `/search/jsonpath?query={query}` endpoint, where `query` is the JSONPath expression.
-                        </span> 
-                        <span class="rfc2119-assertion" id="tdd-search-jsonpath-parameter">
-                            The request MUST contain a valid JSONPath [[?JSONPATH]] as searching parameter.
-                        </span>
-                        <span class="rfc2119-assertion" id="tdd-search-jsonpath-response">
-                            A successful response MUST have 200 (OK) status, contain
-                            <code>application/json</code> Content-Type header, and in
-                            the body a set of complete TDs or a set of TD fragments.
-                        </span>
+                        <div class="issue" data-number="234">
+                            The standardization of JSONPath expressions is in progress by an independent working group.
+                            This section remains non-normative until the release of final
+                            JSONPath specification by IETF.
+                            In the meantime, clients should consider the JSONPath API
+                            as unstable and expect deviations across
+                            <a>Thing Description Directory</a> implementations.
+                        </div>
+                        <!-- <span class="rfc2119-assertion" id="tdd-search-jsonpath-method"> -->
+                        The JSONPath API must allow searching TDs using an HTTP <code>GET</code> request
+                        at `/search/jsonpath?query={query}` endpoint, where `query` is the JSONPath expression.
+                        <!-- </span> -->
+                        <!-- <span class="rfc2119-assertion" id="tdd-search-jsonpath-parameter"> -->
+                        The request must contain a valid JSONPath [[?JSONPATH]] as searching parameter.
+                        <!-- </span> -->
+                        <!-- <span class="rfc2119-assertion" id="tdd-search-jsonpath-response"> -->
+                        A successful response must have 200 (OK) status, contain
+                        <code>application/json</code> Content-Type header, and in
+                        the body a set of complete TDs or a set of TD fragments.
+                        <!-- </span> -->
                         The syntactic search with JSONPath is specified as `searchJSONPath` action in
                         [[[#directory-thing-description]]].
 
@@ -1835,9 +1845,6 @@ img.wot-diagram {
                                 <li>403 (Forbidden): Insufficient rights to the resource.</li>
                             </ul>
                         </p>
-                        <div class="issue" data-number="56">
-                            The standardization of JSONPath expressions is in progress by an independent working group.
-                        </div>
                     </section>
                     <section id="xpath-semantic" class="normative">
                         <h4>Syntactic search: XPath</h4>


### PR DESCRIPTION
See https://github.com/w3c/wot-discovery/issues/231#issuecomment-969057358


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/237.html" title="Last updated on Nov 22, 2021, 3:18 PM UTC (279d096)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/237/22967c4...farshidtz:279d096.html" title="Last updated on Nov 22, 2021, 3:18 PM UTC (279d096)">Diff</a>