### PR TITLE
Delete common terms in terminology section

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,21 +242,11 @@ img.wot-diagram {
             <dfn data-lt="WoT Introduction">Introduction</dfn>,
             <dfn data-lt="WoT Thing Description Directory">Thing Description Directory</dfn>
             (<dfn data-lt="WoT TDD">TDD</dfn>),
-            <dfn data-lt="WoT Partial Thing Description">Partial TD</dfn>
+            <dfn data-lt="WoT Partial Thing Description">Partial TD</dfn>,
+            <dfn data-lt="WoT Enriched Thing Description">Enriched TD</dfn>
             are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
             of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
         </p>
-        
-        <p>
-            In addition, this specification introduces the following definitions:
-        </p>
-        
-        <dl>
-            <dt><dfn data-lt="WoT Enriched Thing Description">Enriched TD</dfn>
-            </dt>
-            <dd>A Thing Description embedded with additional attributes for bookkeeping and discovery. 
-            </dd>
-        </dl>
     </section>
     <section id="architecture" class="informative">
         <h1>Architecture</h1>

--- a/index.html
+++ b/index.html
@@ -234,7 +234,15 @@ img.wot-diagram {
             <dfn>Thing Description</dfn> (<dfn>TD</dfn>),
             <dfn>Property</dfn>,
             <dfn>Action</dfn>,
-            <dfn>Event</dfn>
+            <dfn>Event</dfn>,
+            <dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>,
+            <dfn data-lt="WoT Discoverer">Discoverer</dfn>,
+            <dfn data-lt="WoT Discovery">Discovery</dfn>,
+            <dfn data-lt="WoT Exploration">Exploration</dfn>,
+            <dfn data-lt="WoT Introduction">Introduction</dfn>,
+            <dfn data-lt="WoT Thing Description Directory">Thing Description Directory</dfn>
+            (<dfn data-lt="WoT TDD">TDD</dfn>),
+            <dfn data-lt="WoT Partial Thing Description">Partial TD</dfn>
             are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
             of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
         </p>
@@ -244,51 +252,9 @@ img.wot-diagram {
         </p>
         
         <dl>
-            <dt><dfn data-lt="WoT Anonymous Thing Description">Anonymous TD</dfn>
-            </dt>
-            <dd>A Thing Description without a user-defined identifier (`id` attribute).
-            </dd>
-            <dt><dfn data-lt="WoT Discoverer">Discoverer</dfn>
-            </dt>
-            <dd>An entity that generates and registers a TD with an exploration service
-            on behalf of a <a>Thing</a> which may not be able to do it for itself.
-            </dd>
-            <dt><dfn data-lt="WoT Discovery">Discovery</dfn>
-            </dt>
-            <dd>In the WoT context, the process of finding and retrieving Thing metadata
-            in the form of Thing Descriptions for Things satisfying some criteria of interest.
-            </dd>
             <dt><dfn data-lt="WoT Enriched Thing Description">Enriched TD</dfn>
             </dt>
             <dd>A Thing Description embedded with additional attributes for bookkeeping and discovery. 
-            </dd>
-            <dt><dfn data-lt="WoT Exploration">Exploration</dfn>
-            </dt>
-            <dd>A discovery mechanism that provides access to detailed metadata in the 
-            form of one or more Thing Descriptions.  Exploration mechanisms are in
-            general protected by security mechanism and are accessible only to authorized users.
-            </dd>
-            <dt><dfn data-lt="WoT Introduction">Introduction</dfn>
-            </dt>
-            <dd>A "first contact" discovery mechanism, whose result is a URL that
-            references an exploration mechanism.  Introduction mechanisms themselves
-            should not directly provide metadata, and in general are designed to be 
-            open.
-            </dd>
-            <dt><dfn data-lt="WoT TDD">TDD</dfn>
-            </dt>
-            <dd>Short for Thing Description Directory.
-            </dd>
-            <dt><dfn data-lt="WoT Thing Description Directory">Thing Description Directory</dfn>
-            </dt>
-            <dd>A directory service with a prescribed API that allows the 
-            registration, management, and search of a database of Thing Descriptions.
-            Note that the acronym should be TDD, not TD, to avoid confusion with Thing Descriptions (TDs).
-            </dd>
-            <dt><dfn data-lt="WoT Partial Thing Description">Partial TD</dfn>
-            </dt>
-            <dd>A data model partially conformant to the Thing Description schema by including 
-            only a subset of the attributes.
             </dd>
         </dl>
     </section>


### PR DESCRIPTION
(Fixed for w3c/wot-architecture#613, #240):
Move following terms from Discovery spec to Architecture spec.
- Anonymous TD
- Discoverer
- Exploration
- Introduction

And, delete following terms which are already defined in Architecture spec.
- Discovery
- Thing Description Directory(TDD)
- Partial TD


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-discovery/pull/241.html" title="Last updated on Nov 30, 2021, 6:54 AM UTC (884dab4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/241/1b9a9ae...k-toumura:884dab4.html" title="Last updated on Nov 30, 2021, 6:54 AM UTC (884dab4)">Diff</a>