### PR TITLE
Add placeholder section for thing model

### DIFF
--- a/index.html
+++ b/index.html
@@ -2168,6 +2168,18 @@ be discussed elsewhere and perhaps mentioned as tools for addressing the followi
 
     <section id="directory-api-spec">
         <h1>Directory Service API Specifications</h1>
+        <section id="directory-thing-model">
+            <h3>Directory API Thing Model</h3>
+            <p class="issue" data-number="86">
+                To do: add a
+                <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
+                (`directory.tm.json`)
+                that can derive to the [[[#directory-thing-description]]] as an example.
+                The TM should describe all interaction affordances and indicate which ones
+                are required (i.e. mandatory by this spec). Moreover, it should use placeholders
+                for deployment-specific attributes.
+            </p>
+        </section>
         <section id="directory-thing-description">
             <h3>Directory API Thing Description</h3>
             <p>Below is a generic Thing Description for the Directory API
@@ -2193,9 +2205,8 @@ be discussed elsewhere and perhaps mentioned as tools for addressing the followi
                 this possibility.
             </p>
             <p class="ednote" title="Context URIs">
-		The context URIs are tentative and subject to change. 
-	    </p>
-            <p class="issue" data-number="86"></p>         
+		        The context URIs are tentative and subject to change. 
+	        </p>    
         </section>
     </section>
 


### PR DESCRIPTION
This PR adds a placeholder for directory TM.

Related to #86


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/242.html" title="Last updated on Nov 29, 2021, 3:02 PM UTC (ebb64ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/242/22967c4...farshidtz:ebb64ae.html" title="Last updated on Nov 29, 2021, 3:02 PM UTC (ebb64ae)">Diff</a>