### PR TITLE
Change XPath response to allow all responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -1803,7 +1803,7 @@ img.wot-diagram {
                         The request must contain a valid XPath 3.1 [[xpath-31]] as search parameter.
                         A successful response must have 200 (OK) status, contain
                         <code>application/json</code> Content-Type header, and in
-                        the body, the query response in JSON serialization.
+                        the body, the query response in JSON serialization.  The data schema for the response is defined implicitly by the query and the XPath specification.
                         
                         The syntactic search with XPath is specified as `searchXPath` action in
                         [[[#directory-thing-description]]].

--- a/index.html
+++ b/index.html
@@ -1803,7 +1803,7 @@ img.wot-diagram {
                         The request must contain a valid XPath 3.1 [[xpath-31]] as search parameter.
                         A successful response must have 200 (OK) status, contain
                         <code>application/json</code> Content-Type header, and in
-                        the body a set of complete TDs or a set of TD fragments.
+                        the body, the query response in JSON serialization.
                         
                         The syntactic search with XPath is specified as `searchXPath` action in
                         [[[#directory-thing-description]]].


### PR DESCRIPTION
Fixes #247

This removes the restriction on XPath response model to allow responses for single attribute or functional queries.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/248.html" title="Last updated on Dec 13, 2021, 3:31 PM UTC (e5aefe2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/248/40267a2...farshidtz:e5aefe2.html" title="Last updated on Dec 13, 2021, 3:31 PM UTC (e5aefe2)">Diff</a>