### PR TITLE
Refactor event affordance and event type naming

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -414,7 +414,7 @@
             "forms": [
                 {
                     "op": "subscribeevent",
-                    "href": "/events/create{?diff}",
+                    "href": "/events/thing_created{?diff}",
                     "subprotocol": "sse",
                     "contentType": "text/event-stream",
                     "htv:headers": [
@@ -442,7 +442,7 @@
             "forms": [
                 {
                     "op": "subscribeevent",
-                    "href": "/events/update{?diff}",
+                    "href": "/events/thing_updated{?diff}",
                     "subprotocol": "sse",
                     "contentType": "text/event-stream",
                     "htv:headers": [
@@ -463,7 +463,7 @@
             "forms": [
                 {
                     "op": "subscribeevent",
-                    "href": "/events/delete",
+                    "href": "/events/thing_deleted",
                     "subprotocol": "sse",
                     "contentType": "text/event-stream",
                     "htv:headers": [

--- a/directory.tm.json
+++ b/directory.tm.json
@@ -399,7 +399,7 @@
         }
     },
     "events": {
-        "thingCreation": {
+        "thingCreated": {
             "description": "Registration of Thing Descriptions inside the directory",
             "uriVariables": {
                 "diff": {
@@ -426,7 +426,7 @@
                 }
             ]
         },
-        "thingUpdate": {
+        "thingUpdated": {
             "description": "Updates to Thing Descriptions within the directory",
             "uriVariables": {
                 "diff": {
@@ -454,7 +454,7 @@
                 }
             ]
         },
-        "thingDeletion": {
+        "thingDeleted": {
             "description": "Deletion of Thing Descriptions from the directory",
             "data": {
                 "title": "Partial TD",

--- a/index.html
+++ b/index.html
@@ -1583,7 +1583,7 @@ img.wot-diagram {
                             <span class="rfc2119-assertion" id="tdd-notification-event-types">
                                 The server MUST produce events attributed to the lifecycle of 
                                 the Thing Descriptions within the directory using 
-                                `create`, `update`, and `delete` event types.
+                                `thing_created`, `thing_updated`, and `thing_deleted` event types.
                             </span>
                         </dd>
 
@@ -1604,15 +1604,15 @@ img.wot-diagram {
                                 For example, given the URI Template `/events{/type}`:
                                 <ul>
                                     <li>
-                                        `/events/create` instructs the server to only deliver events of
-                                        type `create`
+                                        `/events/thing_created` instructs the server to only deliver events of
+                                        type `thing_created`
                                     </li>
                                     <li>
                                         `/events` instructs the server to deliver all events
                                     </li>
                                 </ul>
                                 The clients need to subscribe separately to receive a subset of
-                                the events (e.g. only `create` and `delete`) from the server. 
+                                the events (e.g. only `thing_created` and `thing_deleted`) from the server. 
                                 When using HTTP/2, multiple subscriptions on the same domain (HTTP streams) 
                                 get multiplexed on a single connection.
                             </p>
@@ -1638,11 +1638,11 @@ img.wot-diagram {
 
                                     <aside class="example" title="Creation and deletion SSE events for a TD">
                                         <pre>
-                                            event: create
+                                            event: thing_created
                                             data: {"id": "urn:example:simple-td"}
                                             id: event_1
 
-                                            event: delete
+                                            event: thing_deleted
                                             data: {"id": "urn:example:simple-td"}
                                             id: event_2
                                         </pre>
@@ -1650,13 +1650,13 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-create-full">
-                                        When `diff` query parameter is set to `true` and the event has `create` type,
+                                        When `diff` query parameter is set to `true` and the event has `thing_created` type,
                                         the server MAY return the whole TD object as event data.
                                     </span>
                                     
                                     <aside class="example" id="example-create-event-full" title="Full creation SSE event for a TD">
                                         <pre>
-                                            event: create
+                                            event: thing_created
                                             data: {
                                             data:     "@context": [
                                             data:         "https://www.w3.org/2019/wot/td/v1",
@@ -1685,12 +1685,12 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-update-diff">
-                                        When `diff` query parameter is set to `true` and the event has `update` type,
+                                        When `diff` query parameter is set to `true` and the event has `thing_updated` type,
                                         the server MAY inform the client about the updated parts following the
                                         JSON Merge Patch [[RFC7396]] format.
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-update-id">
-                                        An `update` event data that is based on JSON Merge Patch [[RFC7396]]
+                                        A `thing_updated` event data that is based on JSON Merge Patch [[RFC7396]]
                                         MUST always include the identifier of the TD regardless of whether it
                                         is changed.
                                     </span>
@@ -1700,7 +1700,7 @@ img.wot-diagram {
                                         <aside class="example" id="example-update-event-full" 
                                             title="Full update SSE event for a TD with removed description and changed title">
                                             <pre>
-                                                event: create
+                                                event: thing_updated
                                                 data: {
                                                 data:     "description": null,
                                                 data:     "id": "urn:example:simple-td",
@@ -1713,10 +1713,10 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-delete-diff">
-                                        The `diff` query parameter MUST be ignored for `delete` events.
+                                        The `diff` query parameter MUST be ignored for `thing_deleted` events.
                                     </span>
-                                    In other words, the server does not need to include additional properties in
-                                    the payload of `delete` events when `diff` is set to `true`. 
+                                    In other words, the server shall not include additional properties in
+                                    the payload of `thing_deleted` events when `diff` is set to `true`. 
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported">

--- a/index.html
+++ b/index.html
@@ -1734,7 +1734,7 @@ img.wot-diagram {
                     <p>
                         The Notification API is specified as three event affordances in
                         [[[#directory-api-spec]]], namely:
-                        `thingCreation`, `thingUpdate`, and `thingDeletion`.
+                        `thingCreated`, `thingUpdated`, and `thingDeleted`.
                     </p>
 
                     <p class="ednote" title="SSE Authorization Header">


### PR DESCRIPTION
This PR changes the event type's naming convention from Convention B (e.g. `create`) to Conversion C (e.g. `thing_created`); see #197.

Adding the data type is to allow extensions to the notification API to deliver event data other than just TDs.
Changing from action verb to past verb is to make the event type more meaningful when associated with delivered events, since the type value is also to identify the type of event data on the stream.

It closes #197

---

In addition, it changes the event affordance names from nouns to past verbs for consistency with event type values. 

It closes #258


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/251.html" title="Last updated on Jan 24, 2022, 2:11 PM UTC (5b525ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/251/eba3191...farshidtz:5b525ba.html" title="Last updated on Jan 24, 2022, 2:11 PM UTC (5b525ba)">Diff</a>