### PR TITLE
Assertion for optional Notification API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1547,11 +1547,17 @@ img.wot-diagram {
                 </section>
                 <section id="exploration-directory-api-notification" class="normative">
                     <h4>Notification</h4>
-
-                    <p>The Notification API is to notify clients about the changes
-                        to Thing Descriptions maintained within the directory.
+                    <p>
+                        The Notification API is to notify clients about the changes
+                        to <a>TDs</a> maintained within the directory.
+                        <span class="rfc2119-assertion" id="tdd-notification">
+                            Directories MAY implement the Notification API.
+                        </span>
+                    </p>
+                    <p>
+                        
                         <span class="rfc2119-assertion" id="tdd-notification-sse">
-                            The Notification API MUST follow the Server-Sent Events [[EVENTSOURCE]]
+                            The Notification API MUST follow the Server-Sent Events (SSE) [[EVENTSOURCE]]
                             specifications to serve events to clients
                             at `/events` endpoint.
                         </span>
@@ -1563,6 +1569,11 @@ img.wot-diagram {
                             The server SHOULD provide an event ID as the `id` field in each event
                             and respond to re-connecting clients by delivering all missed events.
                         </span>
+                    </p>
+                    <p>
+                        The rest of this section describes the implementation details on top of the SSE protocol.
+                        Realizing the notification functionality using other protocols such as
+                        MQTT are possible and may be formalized in future versions of this specification.
                     </p>
 
                     <dl>


### PR DESCRIPTION
This PR adds an assertion to clarify that the Notification API is optional. It also adds a few sentences to suggest that other protocols are not disallowed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/252.html" title="Last updated on Jan 3, 2022, 3:10 PM UTC (510a3cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/252/c46ebf7...farshidtz:510a3cc.html" title="Last updated on Jan 3, 2022, 3:10 PM UTC (510a3cc)">Diff</a>