### PR TITLE
Permit use of TD Links in well-known URIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,13 @@ img.wot-diagram {
                     When a request is made at the above Well-Known URI, the server MUST return
                     a Thing Description as prescribed in [[[#exploration-self]]].
                 </span>
+		It is sometimes the case that a well-known URI
+		needs to index multiple TDs.  This can be the case,
+		for example, when a URI is inferred from
+		an IP address but multiple Things are hosted
+		at that IP address.  In this case, a single
+		TD is still returned by the process but that
+		TD can use TD Links to reference other TDs.
             </p>
             <p class="ednote" title="Registration of Well-known URI">
                 The service name in Well-Known URI (<code>wot-thing-description</code>) is tentative.


### PR DESCRIPTION
We have discussed using TD Links in TDs returned by well-known URIs to support self-description by endpoints hosting multiple TDs.  This PR adds the following:
- An informative comment in the well-known URI section discussing this use case

To do:
- An informative comment in section 6.1

To discuss:
- Whether we need restrictions/types on TD Links, e.g. they may not point at TDDs, but only TDs, in order to address Issue https://github.com/w3c/wot-discovery/issues/263