### PR TITLE
Remove extra form for things propery

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -54,16 +54,7 @@
             },
             "forms": [
                 {
-                    "href": "/things",
-                    "htv:methodName": "GET",
-                    "response": {
-                        "description": "Success response",
-                        "htv:statusCodeValue": 200,
-                        "contentType": "application/ld+json"
-                    }
-                },
-                {
-                    "href": "/things{?offset,limit,sort_by,sort_order}",
+                    "href": "/things{?offset,limit,format,sort_by,sort_order}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",

--- a/directory.tm.json
+++ b/directory.tm.json
@@ -9,7 +9,7 @@
     ],
     "title": "Thing Description Directory (TDD) Thing Model",
     "version": {
-        "model": "1.0.0-beta"
+        "model": "1.0.0-beta.2"
     },
     "base": "{{DIRECTORY_BASE_URL}}",
     "tm:required": [


### PR DESCRIPTION
Closes #277

This PR:
- removes the first form of the `things` property because the second from covers the same operation, given that uri variables are optional
- adds the missing `format` uri variable


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/282.html" title="Last updated on Mar 7, 2022, 3:29 PM UTC (8ce66ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/282/f03fa88...farshidtz:8ce66ec.html" title="Last updated on Mar 7, 2022, 3:29 PM UTC (8ce66ec)">Diff</a>