### PR TITLE
Move Thing Model to Directory API section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2147,6 +2147,41 @@ img.wot-diagram {
                         </span>
                     </section>
                 </section>
+
+                <section id="directory-api-spec">
+                    <h4>API Specification (Thing Model)</h1>
+
+                    <p class="issue" data-number="86">
+                        To do: add a
+                        <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
+                        (`directory.tm.json`)
+                        that can derive to
+                        <a href="https://github.com/w3c/wot-discovery/blob/main/implementations/example-directory-oauth2.td.json">this TD</a>
+                        as an example.
+                        The <a>TM</a> should describe all interaction affordances and indicate which ones
+                        are required (i.e. mandatory by this spec). Moreover, it should use placeholders
+                        for deployment-specific attributes.
+                        Informative affordances (JSONPath and XPath) should be defined as such.
+                    </p>
+
+                    The API of the directory is specified as a <a>Thing Model</a>.
+                    The Thing Model alone should not be considered as the reference
+                    to implement or interact with a directory.
+                    The full specification is available as human-readable text 
+                    in [[[#exploration-directory-api]]].
+
+                    <pre class="advisement json">
+                        <div data-include='directory.tm.json'></div>
+                    </pre>
+
+                    <p class="issue" data-number="82">
+                        Need to confirm if equivalent OpenAPI spec can be easily created out of the TM.
+                        If yes, a sentence may be added indicating this possibility.
+                    </p>
+                    <p class="ednote" title="Context URIs">
+                        The context URIs are tentative and subject to change. 
+                    </p>
+                </section>
             </section>
 	    <!--
             <section id="exploration-directory-security" class="normative">
@@ -2156,42 +2191,6 @@ img.wot-diagram {
                 </p>
             </section>
 	    -->
-
-            <section id="directory-api-spec">
-                <h3>API Specification (Thing Model)</h1>
-
-                <p class="issue" data-number="86">
-                    To do: add a
-                    <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
-                    (`directory.tm.json`)
-                    that can derive to
-                    <a href="https://github.com/w3c/wot-discovery/blob/main/implementations/example-directory-oauth2.td.json">this TD</a>
-                    as an example.
-                    The <a>TM</a> should describe all interaction affordances and indicate which ones
-                    are required (i.e. mandatory by this spec). Moreover, it should use placeholders
-                    for deployment-specific attributes.
-                    Informative affordances (JSONPath and XPath) should be defined as such.
-                </p>
-
-                The API of the directory is specified as a <a>Thing Model</a>.
-                The Thing Model alone should not be considered as the reference
-                to implement or interact with a directory.
-                The full specification is available as human-readable text 
-                in [[[#exploration-directory-api]]].
-
-                <pre class="advisement json">
-                    <div data-include='directory.tm.json'></div>
-                </pre>
-
-                <p class="issue" data-number="82">
-                    Need to confirm if equivalent OpenAPI spec can be easily created out of the TM.
-                    If yes, a sentence may be added indicating this possibility.
-                </p>
-                <p class="ednote" title="Context URIs">
-                    The context URIs are tentative and subject to change. 
-                </p>
-            </section>
-
         </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2156,6 +2156,42 @@ img.wot-diagram {
                 </p>
             </section>
 	    -->
+
+            <section id="directory-api-spec">
+                <h3>API Specification (Thing Model)</h1>
+
+                <p class="issue" data-number="86">
+                    To do: add a
+                    <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
+                    (`directory.tm.json`)
+                    that can derive to
+                    <a href="https://github.com/w3c/wot-discovery/blob/main/implementations/example-directory-oauth2.td.json">this TD</a>
+                    as an example.
+                    The <a>TM</a> should describe all interaction affordances and indicate which ones
+                    are required (i.e. mandatory by this spec). Moreover, it should use placeholders
+                    for deployment-specific attributes.
+                    Informative affordances (JSONPath and XPath) should be defined as such.
+                </p>
+
+                The API of the directory is specified as a <a>Thing Model</a>.
+                The Thing Model alone should not be considered as the reference
+                to implement or interact with a directory.
+                The full specification is available as human-readable text 
+                in [[[#exploration-directory-api]]].
+
+                <pre class="advisement json">
+                    <div data-include='directory.tm.json'></div>
+                </pre>
+
+                <p class="issue" data-number="82">
+                    Need to confirm if equivalent OpenAPI spec can be easily created out of the TM.
+                    If yes, a sentence may be added indicating this possibility.
+                </p>
+                <p class="ednote" title="Context URIs">
+                    The context URIs are tentative and subject to change. 
+                </p>
+            </section>
+
         </section>
     </section>
 
@@ -2653,41 +2689,6 @@ be discussed elsewhere and perhaps mentioned as tools for addressing the followi
             object in memory for de-serialization. 
 
         </section>
-    </section>
-
-    <section id="directory-api-spec">
-        <h1>Directory Service API Specification (Thing Model)</h1>
-
-        <p class="issue" data-number="86">
-            To do: add a
-            <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
-            (`directory.tm.json`)
-            that can derive to
-            <a href="https://github.com/w3c/wot-discovery/blob/main/implementations/example-directory-oauth2.td.json">this TD</a>
-            as an example.
-            The <a>TM</a> should describe all interaction affordances and indicate which ones
-            are required (i.e. mandatory by this spec). Moreover, it should use placeholders
-            for deployment-specific attributes.
-            Informative affordances (JSONPath and XPath) should be defined as such.
-        </p>
-
-        The API of the directory is specified as a <a>Thing Model</a>.
-        The Thing Model alone should not be considered as the reference
-        to implement or interact with a directory.
-        The full specification is available as human-readable text 
-        in [[[#exploration-directory-api]]].
-
-        <pre class="advisement json">
-            <div data-include='directory.tm.json'></div>
-        </pre>
-
-        <p class="issue" data-number="82">
-            Need to confirm if equivalent OpenAPI spec can be easily created out of the TM.
-            If yes, a sentence may be added indicating this possibility.
-        </p>
-        <p class="ednote" title="Context URIs">
-            The context URIs are tentative and subject to change. 
-        </p>
     </section>
 
     <section id="iana-considerations" class="normative">


### PR DESCRIPTION
Closes #294

I have kept the section name as "API Specification (Thing Model)", because most readers would not know what a Thing Model is and may not understand that it contains the API spec.

Please squash before merging.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/297.html" title="Last updated on Apr 10, 2022, 3:26 PM UTC (30bc734)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/297/12e8d17...farshidtz:30bc734.html" title="Last updated on Apr 10, 2022, 3:26 PM UTC (30bc734)">Diff</a>