### PR TITLE
Section7 fixes

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -410,13 +410,15 @@
                     "op": "subscribeevent",
                     "href": "/events/thing_created{?diff}",
                     "subprotocol": "sse",
-                    "contentType": "text/event-stream",
                     "htv:headers": [
                         {
                             "description": "ID of the last event for reconnection",
                             "htv:fieldName": "Last-Event-ID"
                         }
-                    ]
+                    ],
+                    "response": {
+                        "contentType": "text/event-stream"
+                    }
                 }
             ]
         },
@@ -438,13 +440,15 @@
                     "op": "subscribeevent",
                     "href": "/events/thing_updated{?diff}",
                     "subprotocol": "sse",
-                    "contentType": "text/event-stream",
                     "htv:headers": [
                         {
                             "description": "ID of the last event for reconnection",
                             "htv:fieldName": "Last-Event-ID"
                         }
-                    ]
+                    ],
+                    "response": {
+                        "contentType": "text/event-stream"
+                    }
                 }
             ]
         },
@@ -459,13 +463,15 @@
                     "op": "subscribeevent",
                     "href": "/events/thing_deleted",
                     "subprotocol": "sse",
-                    "contentType": "text/event-stream",
                     "htv:headers": [
                         {
                             "description": "ID of the last event for reconnection",
                             "htv:fieldName": "Last-Event-ID"
                         }
-                    ]
+                    ],
+                    "response": {
+                        "contentType": "text/event-stream"
+                    }
                 }
             ]
         }

--- a/index.html
+++ b/index.html
@@ -1014,7 +1014,8 @@ img.wot-diagram {
                         their <a>TDs</a>. This could be due to protocol-specific limitations,
                         failure, destruction, or ungraceful decommissioning.
                         Such clients should set a reasonably short expiry time and periodically
-                        extend it during the normal operation.
+                        extend it during the normal operation. Extending the expiry happens when
+                        the registration is updated fully, or partially; see [[[#exploration-directory-api-things-update]]].
                        
                         If a client ceases to operate, a directory with purging capability will
                         automatically remove its registration.
@@ -1413,17 +1414,16 @@ img.wot-diagram {
                                 </span>
 
                                 <p>
+                                    This operation is specified as `updateThing` property in 
+                                    [[[#directory-api-spec]]].
+                                </p>
+
+                                <p>
                                     A server that supports expirable TDs will realize such functionality
                                     as described in [[[#exploration-directory-registration-expiry]]].
                                     If `ttl` (relative expiry) is set during the update operation,
                                     the server will calculate and set the `expires` (absolute expiry) value.
                                 </p>
-
-                                <p>
-                                    This operation is specified as `updateThing` property in 
-                                    [[[#directory-api-spec]]].
-                                </p>
-                                
 
                                 <p>
                                     Note: If the target location does not correspond to an existing TD,
@@ -1463,18 +1463,28 @@ img.wot-diagram {
                                 </span>
 
                                 <p>
+                                    This operation is specified as `partiallyUpdateThing` property in 
+                                    [[[#directory-api-spec]]].
+                                </p>
+
+                                <p>
                                     A server that supports expirable TDs will realize such functionality
                                     as described in [[[#exploration-directory-registration-expiry]]].
                                     During the partial update operation, if the resulting <a>TD</a> has 
                                     `ttl` (relative expiry), the server will calculate and set a new
                                     `expires` (absolute expiry) value.
                                 </p>
-
-                                <p>
-                                    This operation is specified as `partiallyUpdateThing` property in 
-                                    [[[#directory-api-spec]]].
-                                </p>
                                 
+                                <p>
+                                    A patch operation is particularly useful to efficiently extend the expiry of
+                                    a registration that uses a `ttl` (relative expiry) value.
+                                    This is typically done by submitting an empty merge patch document,
+                                    i.e. an empty JSON object.
+                                    This effectively translates to performing a partial update operation that
+                                    updates nothing, but triggers the recalculation of `expires` (absolute expiry) value.
+                                    This expiry functionality only work if the server supports it as defined in
+                                    [[[#exploration-directory-registration-expiry]]].
+                                </p>
 
                                 <p>
                                     The following example is a merge patch document to update only the
@@ -1487,8 +1497,12 @@ img.wot-diagram {
                                                     "expires": "2021-01-20T17:02:00Z"
                                                 }
                                             }
-                                        </pre>                    
+                                        </pre> 
+                                        This is a valid way of extending the absolute expiry only if the stored
+                                        TD has no `ttl` (relative expiry).
+                                        For more details, refer to [[[#exploration-directory-registration-expiry]]].                   
                                     </aside>
+
                                 </p>
                             </li>
                         </ul>

--- a/index.html
+++ b/index.html
@@ -956,7 +956,7 @@ img.wot-diagram {
                                     </p>
                                     <p>
                                         For servers that support expirable TDs:
-                                        The server MUST use `ttl` to calculate the `expires` (relative expiry) value.
+                                        The server MUST use `ttl` to calculate the `expires` (absolute expiry) value.
                                     </p>
                                 </td>
                                 <td>optional</td>
@@ -981,7 +981,7 @@ img.wot-diagram {
                 </section>
                 <section id="exploration-directory-registration-expiry" class="normative">
                     <h4>Registration Expiry</h4>
-                    Section [[[#exploration-directory-registration-info]]] introduces few attributes to
+                    Section [[[#exploration-directory-registration-info]]] introduces some attributes to
                     specify and discover the expiry time of registered <a>TDs</a>. 
 
                     <p>


### PR DESCRIPTION

> * [x]  "Section 7.2.1.1 Registration Information introduces few attributes to specify and discover the expiry time of registered TDs." -> "Section 7.2.1.1 Registration Information introduces some attributes to specify and discover the expiry time of registered TDs."

Fixed

> * [x]   This section defines how a registration expires, but it doesn't describe how to prevent it expiring. Is a registrant expected to re-register the Thing Description periodically using the create or update methods of the Things API, or is the directory expected to re-retrieve an up to date Thing Description from somewhere for example?

Extended the description and referenced the update section which elaborates on it.

> * [x]  I've noticed that on the forms for events there is a `contentType` set on requests with a value of `text/event-stream`, but I think this is incorrect because in SSE it's actually the response which has this content type, not the request. You therefore need to set an `Accept` header with a value of `text/event-stream` instead, and the `Content-type` header of the response should then have a value of `text/event-stream`.  For SSE you also need to set the `Connection` header to `keep-alive`, but I don't know whether this is implied by the subprotocol. See below for example metadata:
> 
> ```
> "htv:headers": [
>   {
>     "htv:fieldName": "Accept",
>     "htv:fieldValue": "text/event-stream"
>   },
>   {
>     "htv:fieldName": "Connection",
>     "htv:fieldValue": "keep-alive"
>   }
> ],
> "response": {
>   "htv:statusCodeNumber": 200,
>   "contentType": "text/event-stream"
> }
> ```
> 

We are keeping the spec minimal so we don't re-specify how SSE should be implemented. The `"subprotocol": "sse"` should really be all we need. We've included an entity header and the contentType to support what is written in this document.
I think `Accept` isn't very useful here because the endpoint isn't expected to deliver anything other than `text/event-stream`. IMO, we shouldn't use the content negotiation to allow picking another protocol (if that's your intention).