### PR TITLE
UTF-8 Constraints and Language Negotiation

### DIFF
--- a/index.html
+++ b/index.html
@@ -827,18 +827,16 @@ img.wot-diagram {
                             Content-Type header, and the <a>TD</a> in body.
                         </span>
                         <span class="rfc2119-assertion" id="self-http-alternate-content">
-                            The server MAY provide alternative representations through
+                            The self-description server MAY provide alternative representations through
                             server-driven content negotiation, that is by honouring the 
                             request's Accept header and responding with the supported
                             TD serialization and equivalent Content-Type header.
                         </span>
                         <span class="rfc2119-assertion" id="self-http-alternate-language">
-                            The server MAY provide modified TDs using a different
-                            default language after server-driven content negotiation, 
+                            The self-description server MAY provide modified TDs or error responses 
+                            using a different default language after server-driven content negotiation, 
                             that is by honouring the request's Accept-Language header.
                         </span>
-                        As will be discussed later, the Accept-Language header may also influence
-                        the language used for error responses.
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="self-http-head">
@@ -1151,6 +1149,19 @@ img.wot-diagram {
                         </li>
                     </ul>
                 </p>
+
+                <p>
+                  <span class="rfc2119-assertion" id="tdd-http-alternate-content">
+                     A Directory server MAY provide alternative representations through
+                     server-driven content negotiation, that is by honouring the 
+                     request's Accept header and responding with the supported
+                     TD serialization and equivalent Content-Type header.
+                  </span>
+                  <span class="rfc2119-assertion" id="tdd-http-alternate-language">
+                     A Directory server MAY provide modified TDs or error responses using a different
+                     default language after server-driven content negotiation, 
+                     that is by honouring the request's Accept-Language header.
+                  </span>
 
                 <section id="exploration-directory-api-things" class="normative">
                     <h4>Things API</h4>

--- a/index.html
+++ b/index.html
@@ -1172,7 +1172,7 @@ img.wot-diagram {
                      default language after server-driven content negotiation, 
                      that is by honouring the request's Accept-Language header.
                   </span>
-                     The process of modifyig the default language of a TD using translations already
+                     The process of modifying the default language of a TD using translations already
                      provided in a TD is described in the WoT Thing Description 1.1 specification
                      [[wot-thing-description11]].
 

--- a/index.html
+++ b/index.html
@@ -1151,17 +1151,22 @@ img.wot-diagram {
                 </p>
 
                 <p>
+<!--
                   <span class="rfc2119-assertion" id="tdd-http-alternate-content">
                      A Directory server MAY provide alternative representations through
                      server-driven content negotiation, that is by honouring the 
                      request's Accept header and responding with the supported
                      TD serialization and equivalent Content-Type header.
                   </span>
+-->
                   <span class="rfc2119-assertion" id="tdd-http-alternate-language">
                      A Directory server MAY provide modified TDs or error responses using a different
                      default language after server-driven content negotiation, 
                      that is by honouring the request's Accept-Language header.
                   </span>
+                     The process of modifyig the default language of a TD using translations already
+                     provided in a TD is described in the WoT Thing Description 1.1 specification
+                     [[wot-thing-description11]].
 
                 <section id="exploration-directory-api-things" class="normative">
                     <h4>Things API</h4>

--- a/index.html
+++ b/index.html
@@ -1072,6 +1072,14 @@ img.wot-diagram {
                     </span>
                     This enables both machines and humans to know the high-level error class
                     and fine-grained details.
+                    <span class="rfc2119-assertion" id="tdd-http-error-response-utf-8">
+                        All HTTP API error responses described using Problem Details MUST be encoded using UTF-8.
+                    </span>
+                    <span class="rfc2119-assertion" id="tdd-http-error-response-lang">
+                        HTTP API error responses MAY report details in different languages using
+                        proactive negotiation, if the <code>Accept-Language</code> header field has been
+                        set in the HTTP request [[RFC7231]].
+                    </span>
                 </p>
 
                 <p class="issue" data-number="150">
@@ -1642,7 +1650,7 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-default">
-                                        By default, the collection MUST be sorted alphanumerically 
+                                        By default, the collection MUST be sorted using UTF-8 lexicographical order
                                         by the unique identifier of TDs.
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order">
@@ -1651,12 +1659,21 @@ img.wot-diagram {
                                         and `sort_order` to choose the order
                                         (i.e. `asc` or `desc` for ascending and descending ordering).
                                     </span>
+                                    <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">
+                                        A server MUST reject requests to sort on fields that do not have 
+                                        values that are orderable basic types, 
+                                        with a 400 (Bad Request) status.
+                                    </span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-unsupported">
                                         If the server does not support custom sorting,
                                         it MUST reject the request with 501 (Not Implemented) status.
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-nextlink">
                                         If sorting attributes are accepted, they MUST be added consistently to all `next` links.
+                                    </span>
+                                    <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-utf-8">
+                                        Sorting order MUST always be defined using lexicographical ordering on
+                                        a UTF-8 encoding of the relevant fields.
                                     </span>
                                 </li>
                             </ul>
@@ -1798,6 +1815,14 @@ img.wot-diagram {
                                 with `field` and `description` fields.
                             </span>
                             This is necessary to represent the error in a machine-readable way. 
+                            <span class="rfc2119-assertion" id="tdd-validation-response-utf-8">
+                                All validation error responses described using Problem Details MUST be encoded using UTF-8.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-validation-response-lang">
+                                Validation error responses MAY report details in different languages using
+                                proactive negotiation, if the <code>Accept-Language</code> header field has been
+                                set in the HTTP request [[RFC7231]].
+                            </span>
                         </p>
                         
                         [[[#example-validation-error]]] is an example error response with two validation errors.

--- a/index.html
+++ b/index.html
@@ -832,6 +832,13 @@ img.wot-diagram {
                             request's Accept header and responding with the supported
                             TD serialization and equivalent Content-Type header.
                         </span>
+                        <span class="rfc2119-assertion" id="self-http-alternate-language">
+                            The server MAY provide modified TDs using a different
+                            default language after server-driven content negotiation, 
+                            that is by honouring the request's Accept-Language header.
+                        </span>
+                        As will be discussed later, the Accept-Language header may also influence
+                        the language used for error responses.
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="self-http-head">

--- a/publication/3-cr/index.html
+++ b/publication/3-cr/index.html
@@ -1054,6 +1054,14 @@ img.wot-diagram {
                     </span>
                     This enables both machines and humans to know the high-level error class
                     and fine-grained details.
+                    <span class="rfc2119-assertion" id="tdd-http-error-response-utf-8">
+                        All HTTP API error responses described using Problem Details MUST be encoded using UTF-8.
+                    </span>
+                    <span class="rfc2119-assertion" id="tdd-http-error-response-lang">
+                        HTTP API error responses MAY report details in different languages using
+                        proactive negotiation, if the <code>Accept-Language</code> header field has been
+                        set in the HTTP request [[RFC7231]].
+                    </span>
                 </p>
 
                 <p class="issue" data-number="150">
@@ -1783,6 +1791,14 @@ img.wot-diagram {
                                 with `field` and `description` fields.
                             </span>
                             This is necessary to represent the error in a machine-readable way. 
+                            <span class="rfc2119-assertion" id="tdd-validation-response-utf-8">
+                                All validation error responses described using Problem Details MUST be encoded using UTF-8.
+                            </span>
+                            <span class="rfc2119-assertion" id="tdd-validation-response-lang">
+                                Validation error responses MAY report details in different languages using
+                                proactive negotiation, if the <code>Accept-Language</code> header field has been
+                                set in the HTTP request [[RFC7231]].
+                            </span>
                         </p>
                         
                         [[[#example-validation-error]]] is an example error response with two validation errors.

--- a/publication/3-cr/index.html
+++ b/publication/3-cr/index.html
@@ -1632,12 +1632,21 @@ img.wot-diagram {
                                         and `sort_order` to choose the order
                                         (i.e. `asc` or `desc` for ascending and descending ordering).
                                     </span>
+                                    <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">
+                                        A server MUST reject requests to sort on fields that do not have 
+                                        values that are orderable basic types, 
+                                        with a 501 (Not Implemented) status.
+                                    </span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-unsupported">
                                         If the server does not support custom sorting,
                                         it MUST reject the request with 501 (Not Implemented) status.
                                     </span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-nextlink">
                                         If sorting attributes are accepted, they MUST be added consistently to all `next` links.
+                                    </span>
+                                    <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-utf-8">
+                                        Sorting order MUST always be defined using lexicographical ordering on
+                                        a UTF-8 encoding of the relevant fields.
                                     </span>
                                 </li>
                             </ul>


### PR DESCRIPTION
Resolves #316.  Resolves #281.  Resolves #304.  Resolves #279.

- Requires UTF-8 encoding of Problem Details
    - In Problem Details in validation
    - In Problem Details for directory API
    - ... Problem Details not required for self-description... huh.
- Allows language negotiation using Accept-Language header for both TDs and errors
    - originally I was only planning this for errors, but it's inconsistent to not also honor it for TDs
    - you need the Accept-Language header on POST and GET requests that normally would register and fetch TDs, so if I do a GET on the "things" endpoint with Accept-Language set to some value, logically it would apply to the valid results, not just to errors...
    - There was an assertion for "Accept" but is for Content-Type, not language: "The server MAY provide alternative representations through server-driven content negotiation, that is by honouring the request's Accept header and responding with the supported TD serialization and equivalent Content-Type header."
    - I also noticed there was an assertion for this in self-description but not for directories, so while I was at it I added a similar assertion for directories
- Defines sorting order to be lexicographic UTF-8
    - Simple enough for small devices
    - Language-specific sorting rules for ALL languages just not feasible on smaller machines
- Disallows sorting on fields that are not basic types
    - Don't know if we need to define this, or if there is a JSON standard we can reference
    - But generally the spec allows any implementation to opt out of sorting on anything but ids anyway


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/318.html" title="Last updated on May 23, 2022, 2:20 PM UTC (752d730)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/318/3afc3df...mmccool:752d730.html" title="Last updated on May 23, 2022, 2:20 PM UTC (752d730)">Diff</a>