### PR TITLE
Suppress Unused Dfns Respec Error

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
             "check-punctuation": true,
             "local-refs-exist": true,
             "no-http-props": true,
-            "no-headingless-sections": true
+            "no-headingless-sections": true,
+            "no-unused-dfns": false
         },
         doJsonLd : true,
         specStatus : "ED",


### PR DESCRIPTION
- in `respecConfig`, set `lint: { "no-unused-dfns": false }` to suppress 8 respec warnings about unused dfns 
- this however does turn off the warnings globally, so might miss actual problems... but probably not
- these were bogus because the dfns that are causing the problem are actually references to definitions in Architecture


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/322.html" title="Last updated on May 26, 2022, 1:29 PM UTC (35e0208)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/322/4f5ffec...mmccool:35e0208.html" title="Last updated on May 26, 2022, 1:29 PM UTC (35e0208)">Diff</a>