### PR TITLE
Add text for discovery using CoAP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2980,6 +2980,12 @@ img.wot-diagram {
                 The HTTP/1.1 chunked transfer encoding is not supported in HTTP/2.
                 <!-- </span> -->
                 </li>
+                <li>
+        <!-- <span class="rfc2119-assertion" id="perf-inc-chunked-3"> -->
+                CoAP servers should handle the data incrementally using
+                block-wise transfer [[RFC7959]].
+               <!-- </span> -->
+                </li>
             </ul>
             <p> 
             Most HTTP servers and clients automatically process the data that is transferred 

--- a/index.html
+++ b/index.html
@@ -1112,6 +1112,71 @@ img.wot-diagram {
                     </p>
                 </dd>
             </dl>
+            <dl>
+                <dt>CoAP</dt>
+                <dd>
+                <p>
+                    <span class="rfc2119-assertion" id="service-coap-secure">
+                        A CoAP-based TD Server providing a <a>TD</a> SHOULD use the appropriate transport
+                        security mechanism for the transport protocol used (i.e., DTLS for CoAP over UDP
+                        or TLS for CoAP over TCP).
+                    </span>
+                    <span class="rfc2119-assertion" id="service-coap-access-control">
+                        A CoAP-based TD Server providing a <a>TD</a>
+                        SHOULD provide the resource only after performing necessary
+                        authentication and authorization.
+                    </span>
+                </p>
+                <p>
+                    <span class="rfc2119-assertion" id="service-coap-method">
+                        A CoAP-based TD Server providing a <a>TD</a>
+                        MUST serve that resource with a `GET` method.
+                    </span>
+                    <span class="rfc2119-assertion" id="service-coap-resp">
+                        A successful response from a CoAP-based TD Server providing a <a>TD</a>
+                        MUST have a 2.05 (Content) status, contain a Content-Format option
+                        with value 432 (`application/td+json`), and the <a>TD</a> in the payload.
+                    </span>
+                    Note that the payload might be split over multiple message exchanges using
+                    block-wise transfer [[RFC7959]].
+                    <span class="rfc2119-assertion" id="service-coap-alternate-content">
+                        A CoAP-based TD Server providing a <a>TD</a>
+                        MAY provide alternative representations through
+                        server-driven content negotiation, that is by honouring the
+                        request's Accept option and responding with the supported
+                        TD serialization and equivalent Content-Format option.
+                    </span>
+                </p>
+                <p>
+                    <span class="rfc2119-assertion" id="service-coap-size2">
+                        A CoAP-based TD Server providing a <a>TD</a>
+                        SHOULD respond to requests containing a Size2 option by including
+                        the size estimate of the TD in its next response.
+                    </span>
+                    This is relevant when obtaining a TD using block-wise transfer and
+                    enables clients to abort the retrieval if the total payload size should be too
+                    large for them to process.
+                </p>
+                <p>
+                    In constrained environments, a single <a>TD</a> may be too large to process
+                    for the server or clients.
+                    See [[[#perf-incremental-transfer]]] for protocol-specific recommendations on
+                    incremental transfer of the requested payload.
+                </p>
+
+                <p>
+                    Error responses:
+                    <ul>
+                        <li>
+                            4.01 (Unauthorized): No authentication.
+                        </li>
+                        <li>
+                            4.03 (Forbidden): Insufficient rights to the resource.
+                        </li>
+                    </ul>
+                </p>
+            </dd>
+            </dl>
         </section>
         
         <section id="exploration-directory" class="normative">

--- a/index.html
+++ b/index.html
@@ -2983,8 +2983,9 @@ img.wot-diagram {
                 </li>
                 <li>
         <!-- <span class="rfc2119-assertion" id="perf-inc-chunked-3"> -->
-                CoAP servers should handle the data incrementally using
-                block-wise transfer [[RFC7959]].
+                CoAP servers must suppoert block-wise transfer [[RFC7959]] when relying
+                on an unreliable transport protocol like UDP and should support it when
+                using a reliable transport protocol like TCP or WebSockets [[RFC8323]].
                <!-- </span> -->
                 </li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -1117,9 +1117,10 @@ img.wot-diagram {
                 <dd>
                 <p>
                     <span class="rfc2119-assertion" id="service-coap-secure">
-                        A CoAP-based TD Server providing a <a>TD</a> SHOULD use the appropriate transport
-                        security mechanism for the transport protocol used (i.e., DTLS for CoAP over UDP
-                        or TLS for CoAP over TCP).
+                        A CoAP-based TD Server providing a <a>TD</a> SHOULD use the appropriate
+                        transport-layer security mechanism for the transport protocol used
+                        (e.g., DTLS for CoAP over UDP [[[RFC7252]]] and TLS for CoAP over TCP
+                        or WebSockets [[RFC8323]]).
                     </span>
                     <span class="rfc2119-assertion" id="service-coap-access-control">
                         A CoAP-based TD Server providing a <a>TD</a>
@@ -1144,16 +1145,16 @@ img.wot-diagram {
                         MAY provide alternative representations through
                         server-driven content negotiation, that is by honouring the
                         request's Accept option and responding with the supported
-                        TD serialization and equivalent Content-Format option.
+                        <a>TD</a> serialization and equivalent Content-Format option.
                     </span>
                 </p>
                 <p>
                     <span class="rfc2119-assertion" id="service-coap-size2">
-                        A CoAP-based TD Server providing a <a>TD</a>
+                        A CoAP-based <a>TD</a> Server providing a <a>TD</a>
                         SHOULD respond to requests containing a Size2 option by including
-                        the size estimate of the TD in its next response.
+                        the size estimate of the <a>TD</a> in its next response.
                     </span>
-                    This is relevant when obtaining a TD using block-wise transfer and
+                    This is relevant when obtaining a <a>TD</a> using block-wise transfer and
                     enables clients to abort the retrieval if the total payload size should be too
                     large for them to process.
                 </p>

--- a/index.html
+++ b/index.html
@@ -1116,19 +1116,6 @@ img.wot-diagram {
                 <dt>CoAP</dt>
                 <dd>
                 <p>
-                    <span class="rfc2119-assertion" id="service-coap-secure">
-                        A CoAP-based TD Server providing a <a>TD</a> SHOULD use the appropriate
-                        transport-layer security mechanism for the transport protocol used
-                        (e.g., DTLS for CoAP over UDP [[[RFC7252]]] and TLS for CoAP over TCP
-                        or WebSockets [[RFC8323]]).
-                    </span>
-                    <span class="rfc2119-assertion" id="service-coap-access-control">
-                        A CoAP-based TD Server providing a <a>TD</a>
-                        SHOULD provide the resource only after performing necessary
-                        authentication and authorization.
-                    </span>
-                </p>
-                <p>
                     <span class="rfc2119-assertion" id="service-coap-method">
                         A CoAP-based TD Server providing a <a>TD</a>
                         MUST serve that resource with a `GET` method.


### PR DESCRIPTION
This PR adds a number of CoAP-specific assertions for discovery from Thing Description Servers to the document, modelled after the ones for HTTP.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/334.html" title="Last updated on Jun 13, 2022, 2:00 PM UTC (35d7b3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/334/0549320...JKRhb:35d7b3c.html" title="Last updated on Jun 13, 2022, 2:00 PM UTC (35d7b3c)">Diff</a>