### PR TITLE
Remove endline/whitespace from end of assertions

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,13 +552,11 @@ img.wot-diagram {
                typed by a user.
                 <span class="rfc2119-assertion" id="introduction-direct-thing-description">
                     A request on all such URLs MUST result in a TD as prescribed in
-                    [[[#exploration-mech]]].
-                </span>
+                    [[[#exploration-mech]]].</span>
                 For self-describing Things, this can be the TD of the Thing itself.
                 <span class="rfc2119-assertion" id="introduction-direct-directory-description">
                    If the URL references a <a>Thing Description Directory</a>, this MUST be the Directory Description of the
-                    <a>Thing Description Directory</a>.
-                </span>
+                    <a>Thing Description Directory</a>.</span>
             </p>
         </section>
         <section id="introduction-well-known" class="normative">
@@ -572,8 +570,7 @@ img.wot-diagram {
             <p>
                 <span class="rfc2119-assertion" id="introduction-well-known-thing-description">
                     When a request is made at the above Well-Known URI, the server MUST return
-                    a Thing Description as prescribed in [[[#exploration-mech]]].
-                </span>
+                    a Thing Description as prescribed in [[[#exploration-mech]]].</span>
             </p>
             <p class="ednote" title="Registration of Well-known URI">
                 The service name in Well-Known URI (<code>wot-thing-description</code>) is tentative.
@@ -594,11 +591,9 @@ img.wot-diagram {
             </p>
             <p>
                 <span class="rfc2119-assertion" id="introduction-dns-sd-service-name">
-                    The Service Name to indicate the Thing or <a>Thing Description Directory</a> MUST be <code>_wot</code>.
-                </span>
+                    The Service Name to indicate the Thing or <a>Thing Description Directory</a> MUST be <code>_wot</code>.</span>
                 <span class="rfc2119-assertion" id="introduction-dns-sd-service-name-directory">
-                    The Service Name to indicate the <a>Thing Description Directory</a> MUST be <code>_directory._sub._wot</code>.
-                </span>
+                    The Service Name to indicate the <a>Thing Description Directory</a> MUST be <code>_directory._sub._wot</code>.</span>
             </p>
             <p class="ednote" title="Service Names in existing implementations">
                 The Service Names <code>_wot</code> and <code>_directory._sub._wot</code>
@@ -670,12 +665,10 @@ img.wot-diagram {
             <p>
                 <span class="rfc2119-assertion" id="introduction-core-rd-resource-type-thing">
                     The resource type (<code>rt</code>) of the Link that targets the Thing Description of the Thing
-                    MUST be <code>wot.thing</code>. 
-                </span>
+                    MUST be <code>wot.thing</code>.</span>
                 <span class="rfc2119-assertion" id="introduction-core-rd-resource-type-directory">
                     The resource type of the Link that targets the Directory Description of the <a>Thing Description Directory</a>
-                    MUST be <code>wot.directory</code>.
-                </span>
+                    MUST be <code>wot.directory</code>.</span>
             </p>
             <p class="ednote">
                 The resource types <code>wot.thing</code> and <code>wot.directory</code> are tentative.
@@ -690,8 +683,7 @@ img.wot-diagram {
             <p>
                 <span class="rfc2119-assertion" id="introduction-did-service-endpoint">
                     The DID Document obtained by resolving the DID of a Thing or <a>Thing Description Directory</a> MUST
-                    contain a Service Endpoint which points to a Thing Description describing that Thing or <a>Thing Description Directory</a>.
-                </span>
+                    contain a Service Endpoint which points to a Thing Description describing that Thing or <a>Thing Description Directory</a>.</span>
             </p>
             <aside class="example" title="A Example Service Endpoint in a DID Document">
                 <pre>
@@ -788,8 +780,7 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-directory-description-type"> 
                         A TD which describes a Thing Description Directory instance MUST use type `ThingDirectory` from the
-                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingDirectory`.
-                    </span>
+                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingDirectory`.</span>
                     <p>
                         A TD of this class can be derived from Directory's Thing Model; see [[[#directory-api-spec]]].
                     </p>
@@ -803,13 +794,11 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-link-description-type"> 
                         A TD which describes a reference to another TD MUST use type `ThingLink` from the
-                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingLink`.
-                    </span>
+                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingLink`.</span>
                     <span class="rfc2119-assertion" id="exploration-link-description-link"> 
                         A Thing Link MUST define the referenced TD as a Link with
                         `describedby` link relation type, `application/td+json` media type
-                        and `href` set to the target URL.
-                    </span>
+                        and `href` set to the target URL.</span>
 
                     <p>
                         [[[#example-td-link-type]]] is an example Thing Link.
@@ -974,16 +963,14 @@ img.wot-diagram {
                 at an API endpoint intended to serve a TD
                 MUST include a <code>WWW-Authenticate</code> header
                 and any other headers
-                describing the required authorizations. 
-                </span>
+                describing the required authorizations.</span>
                 For details of the requirements, the IANA registry should be consulted for
                 each of the above authentication schemes.  
                 <span class="rfc2119-assertion" id="exploration-secboot-oauth2-flows">
                 If the OAuth2 <code>code</code> flow is used during security bootstrapping, the
                 "302 (Found)" or "303 (See Other)" response code MUST be used for redirection
                 to the authentication server,
-                with access credentials eventually being represented with bearer tokens.
-                </span>
+                with access credentials eventually being represented with bearer tokens.</span>
                 Note that the other OAuth2 flows supported in WoT Thing Description 1.1,
                 <code>client</code> and <code>device</code>, both expect the initial access
                 to be to the authentication server, not the final endpoint, and so cannot be
@@ -1049,8 +1036,7 @@ img.wot-diagram {
                     <p>
                         <span class="rfc2119-assertion" id="service-http-method"> 
                             An HTTP-based TD Server providing a <a>TD</a> 
-                            MUST serve that resource with a `GET` method.
-                        </span>
+                            MUST serve that resource with a `GET` method.</span>
                         <span class="rfc2119-assertion" id="service-http-resp">
                             A successful response from an HTTP-based TD Server providing a <a>TD</a>
                             MUST have 200 (OK) status and the <a>TD</a> in the body.</span>
@@ -1071,15 +1057,13 @@ img.wot-diagram {
                             An HTTP-based TD Server providing a <a>TD</a> 
                             MAY provide modified TDs or error responses 
                             using a different default language after server-driven content negotiation, 
-                            that is by honouring the request's Accept-Language header.
-                        </span>
+                            that is by honouring the request's Accept-Language header.</span>
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="service-http-head">
                             An HTTP-based TD Server providing a <a>TD</a> 
                             MUST respond to `HEAD` requests by returning only the headers
-                            equivalent to those returned by a `GET` request to the same endpoint.
-                        </span>
+                            equivalent to those returned by a `GET` request to the same endpoint.</span>
                         This enables clients to retrieve HTTP headers such as the Content-Length in advance 
                         to know the size of the <a>TD</a> (in bytes) and decide on an efficient query strategy.
                     </p>
@@ -1109,13 +1093,11 @@ img.wot-diagram {
                 <p>
                     <span class="rfc2119-assertion" id="service-coap-method">
                         A CoAP-based TD Server providing a <a>TD</a>
-                        MUST serve that resource with a `GET` method.
-                    </span>
+                        MUST serve that resource with a `GET` method.</span>
                     <span class="rfc2119-assertion" id="service-coap-resp">
                         A successful response from a CoAP-based TD Server providing a <a>TD</a>
                         MUST have a 2.05 (Content) status, contain a Content-Format option
-                        with value 432 (`application/td+json`), and the <a>TD</a> in the payload.
-                    </span>
+                        with value 432 (`application/td+json`), and the <a>TD</a> in the payload.</span>
                     Note that the payload might be split over multiple message exchanges using
                     block-wise transfer [[RFC7959]].
                     <span class="rfc2119-assertion" id="service-coap-alternate-content">
@@ -1123,15 +1105,13 @@ img.wot-diagram {
                         MAY provide alternative representations through
                         server-driven content negotiation, that is by honouring the
                         request's Accept option and responding with the supported
-                        <a>TD</a> serialization and equivalent Content-Format option.
-                    </span>
+                        <a>TD</a> serialization and equivalent Content-Format option.</span>
                 </p>
                 <p>
                     <span class="rfc2119-assertion" id="service-coap-size2">
                         A CoAP-based <a>TD</a> Server providing a <a>TD</a>
                         SHOULD respond to requests containing a Size2 option by including
-                        the size estimate of the <a>TD</a> in its next response.
-                    </span>
+                        the size estimate of the <a>TD</a> in its next response.</span>
                     This is relevant when obtaining a <a>TD</a> using block-wise transfer and
                     enables clients to abort the retrieval if the total payload size should be too
                     large for them to process.
@@ -1190,9 +1170,8 @@ img.wot-diagram {
                     The following table lists the registration information attributes for
                     use within <a>TDs</a> that embed or reference the Discovery context. 
                     Note that only an <a>Enriched TD</a> embeds the registration information. 
-		    <span class="rfc2119-assertion" id="tdd-context-injection">
-			An <a>Enriched TD</a> MUST contain in its @context the URI <code>https://w3c.github.io/wot-discovery/context/discovery-context.jsonld</code>
-		    </span>
+		            <span class="rfc2119-assertion" id="tdd-context-injection">An <a>Enriched TD</a>
+                        MUST contain in its @context the URI <code>https://w3c.github.io/wot-discovery/context/discovery-context.jsonld</code>.</span>
                     In this table,
                     client refers to the producer or consumer of a <a>TD</a> and server refers to
                     the <a>Thing Description Directory</a>.
@@ -1306,14 +1285,12 @@ img.wot-diagram {
                         removal of obsolete or accidental registrations.
                         <span class="rfc2119-assertion" id="tdd-registrationinfo-expiry-purge">
                             Servers SHOULD periodically purge TDs that are past 
-                            their expiry times.
-                        </span>
+                            their expiry times.</span>
                         Prescribing a global mandate or upper limit for the expiry time is
                         application-specific and beyond the scope of this specification.
                         <span class="rfc2119-assertion" id="tdd-registrationinfo-expiry-config">
                             The servers MAY mandate or set a configurable upper limit to expiry times
-                            and refuse incompliant requests.
-                        </span>
+                            and refuse incompliant requests.</span>
                         
                         The purging by servers is particularly beneficial when interacting with
                         clients (e.g. IoT devices) that are unable to explicitly deregister
@@ -1335,12 +1312,10 @@ img.wot-diagram {
                     to enable management and retrieval of such TDs from the directory.
                     <span class="rfc2119-assertion" id="tdd-anonymous-td-identifier">
                         In situations where the server exposes an Anonymous TD (e.g. retrieval, listing, search),
-                        it MUST add the local identifier to the TD to allow local referencing.
-                    </span>
+                        it MUST add the local identifier to the TD to allow local referencing.</span>
 
                     <span class="rfc2119-assertion" id="tdd-anonymous-td-local-uuid">
-                        The local identifier SHOULD be a UUID Version 4, presented as a URN [[RFC4122]].
-                    </span>
+                        The local identifier SHOULD be a UUID Version 4, presented as a URN [[RFC4122]].</span>
                     UUID Version 4 is a random or pseudo-random number which does not carry unintended information
                     about the host or the resource.
                 </section>
@@ -1360,18 +1335,15 @@ img.wot-diagram {
                     this section for success and error responses.
                     <span class="rfc2119-assertion" id="tdd-http-error-response"> 
                         The HTTP API MUST use the Problem Details [[RFC7807]] format to carry
-                        error details in HTTP client error (4xx) and server error (5xx) responses.
-                    </span>
+                        error details in HTTP client error (4xx) and server error (5xx) responses.</span>
                     This enables both machines and humans to know the high-level error class
                     and fine-grained details.
                     <span class="rfc2119-assertion" id="tdd-http-error-response-utf-8">
-                        All HTTP API error responses described using Problem Details MUST be encoded using UTF-8.
-                    </span>
+                        All HTTP API error responses described using Problem Details MUST be encoded using UTF-8.</span>
                     <span class="rfc2119-assertion" id="tdd-http-error-response-lang">
                         HTTP API error responses MAY report details in different languages using
                         proactive negotiation, if the <code>Accept-Language</code> header field has been
-                        set in the HTTP request [[RFC7231]].
-                    </span>
+                        set in the HTTP request [[RFC7231]].</span>
                 </p>
 
                 <p class="issue" data-number="150">
@@ -1409,8 +1381,7 @@ img.wot-diagram {
                 <p>
                     <span class="rfc2119-assertion" id="tdd-http-head"> 
                         For each HTTP endpoint that responds to the `GET` method, the server MUST accept `HEAD` 
-                        requests and return only the headers.
-                    </span>
+                        requests and return only the headers.</span>
                     This allows clients to retrieve headers such as the Content-Length without receiving the body
                     and decide on a suitable strategy to query the information. For example, a constrained client can
                     request only the necessary parts of an object (using an appropriate search query) or 
@@ -1453,14 +1424,13 @@ img.wot-diagram {
                 </p>
 
                 <p>
-                  <span class="rfc2119-assertion" id="tdd-http-alternate-language">
-                     A Directory server MAY provide modified TDs or error responses using a different
-                     default language after server-driven content negotiation, 
-                     that is by honouring the request's Accept-Language header.
-                  </span>
-                     The process of modifying the default language of a TD using translations already
-                     provided in a TD is described in the WoT Thing Description 1.1 specification
-                     [[wot-thing-description11]].
+                    <span class="rfc2119-assertion" id="tdd-http-alternate-language">
+                        A Directory server MAY provide modified TDs or error responses using a different
+                        default language after server-driven content negotiation, 
+                        that is by honouring the request's Accept-Language header.</span>
+                    The process of modifying the default language of a TD using translations already
+                    provided in a TD is described in the WoT Thing Description 1.1 specification
+                    [[wot-thing-description11]].
 
                 <section id="exploration-directory-api-things" class="normative">
                     <h4>Things API</h4>
@@ -1543,8 +1513,7 @@ img.wot-diagram {
                         <p>
                             <span class="rfc2119-assertion" id="tdd-things-create-known-vs-anonymous"> 
                                 A TD which is identified with an `id` attribute MUST be handled 
-                                differently with one that has no identifier (<a>Anonymous TD</a>).
-                            </span>
+                                differently with one that has no identifier (<a>Anonymous TD</a>).</span>
                             The create operations are elaborated below:
                         </p>
                         <ul>
@@ -1552,18 +1521,15 @@ img.wot-diagram {
                                 <span class="rfc2119-assertion" id="tdd-things-create-known-td">
                                     A TD that has an `id` MUST be submitted to the directory in the body of an HTTP `PUT` request
                                     at `/things/{id}` endpoint, where `id` is the unique TD identifier,
-                                    present inside the TD object.
-                                </span>
+                                    present inside the TD object.</span>
                                 An <a>Anonymous TD</a> is handled differently; see below.
                                 <span class="rfc2119-assertion" id="tdd-things-create-known-contenttype">
                                     The request SHOULD contain `application/td+json` Content-Type header for 
-                                    JSON serialization of TD.
-                                </span>
+                                    JSON serialization of TD.</span>
                                 The TD object is validated in accordance with [[[#validation]]].
                                 <span class="rfc2119-assertion" id="tdd-things-create-known-td-resp">  
                                     Upon successful processing, the server MUST respond with
-                                    201 (Created) status.                           
-                                </span>
+                                    201 (Created) status.</span>
 
                                 <p>
                                     Note: If the target location corresponds to an existing TD,
@@ -1578,17 +1544,14 @@ img.wot-diagram {
                             <li>
                                 <span class="rfc2119-assertion" id="tdd-things-create-anonymous-td">
                                     An <a>Anonymous TD</a> MUST be submitted to the directory in the body of
-                                    an HTTP `POST` request at `/things` endpoint.
-                                </span>
+                                    an HTTP `POST` request at `/things` endpoint.</span>
                                 <span class="rfc2119-assertion" id="tdd-things-create-anonymous-contenttype">
                                     The request SHOULD contain `application/td+json` Content-Type header for 
-                                    JSON serialization of TD.
-                                </span>
+                                    JSON serialization of TD.</span>
                                 The TD object is validated in accordance with [[[#validation]]].
                                 <span class="rfc2119-assertion" id="tdd-things-create-anonymous-td-resp">
                                     Upon successful processing, the server MUST respond with 201 (Created) status
-                                    and a Location header containing a system-generated identifier for the TD.
-                                </span>
+                                    and a Location header containing a system-generated identifier for the TD.</span>
                                 The scheme of the system-generated ID is described in [[[#exploration-directory-anonymous-td]]].
 
                                 <p>
@@ -1614,11 +1577,9 @@ img.wot-diagram {
                         <p>
                             <span class="rfc2119-assertion" id="tdd-things-retrieve">
                                 The retrieval of an existing TD MUST be done using an HTTP `GET` request
-                                at `/things/{id}` endpoint, where `id` is the unique TD identifier.
-                            </span>
+                                at `/things/{id}` endpoint, where `id` is the unique TD identifier.</span>
                             <span class="rfc2119-assertion" id="tdd-things-retrieve-resp">
-                                A successful response MUST have 200 (OK) status and the requested TD in the body.
-                            </span>
+                                A successful response MUST have 200 (OK) status and the requested TD in the body.</span>
                             <span class="rfc2119-assertion" id="tdd-things-retrieve-resp-content-type">
                                 A successful response with JSON serialization MUST contain `application/json`
                                 or more specifically, `application/td+json` in the Content-Type header.</span>
@@ -1744,16 +1705,13 @@ img.wot-diagram {
                             <li>
                                 <span class="rfc2119-assertion" id="tdd-things-update">
                                     A modified TD MUST replace an existing one when submitted using an HTTP `PUT` request
-                                    at `/things/{id}` endpoint, where `id` is the identifier of the existing TD.
-                                </span>
+                                    at `/things/{id}` endpoint, where `id` is the identifier of the existing TD.</span>
                                 <span class="rfc2119-assertion" id="tdd-things-update-contenttype">
                                     The request SHOULD contain `application/td+json` Content-Type header for JSON
-                                    serialization of TD.
-                                </span>
+                                    serialization of TD.</span>
                                 The TD object is validated in accordance with [[[#validation]]].
                                 <span class="rfc2119-assertion" id="tdd-things-update-resp">
-                                    Upon success, the server MUST respond with 204 (No Content) status. 
-                                </span>
+                                    Upon success, the server MUST respond with 204 (No Content) status.</span>
 
                                 <p>
                                     This operation is specified as `updateThing` property in 
@@ -1778,20 +1736,16 @@ img.wot-diagram {
                                 <span class="rfc2119-assertion" id="tdd-things-update-partial">
                                     An existing TD MUST be partially modified when the modified parts are submitted using an 
                                     HTTP `PATCH` request
-                                    at `/things/{id}` endpoint, where `id` is the identifier of the existing TD.
-                                </span>
+                                    at `/things/{id}` endpoint, where `id` is the identifier of the existing TD.</span>
                                 <span class="rfc2119-assertion" id="tdd-things-update-partial-mergepatch">
                                     The partial update MUST be processed using the JSON merge patch
-                                    format described in [[RFC7396]].
-                                </span>
+                                    format described in [[RFC7396]].</span>
                                 <span class="rfc2119-assertion" id="tdd-things-update-partial-contenttype">
                                     The request MUST contain `application/merge-patch+json` Content-Type header for JSON
-                                    serialization of the merge patch document.
-                                </span>
+                                    serialization of the merge patch document.</span>
                                 <span class="rfc2119-assertion" id="tdd-things-update-partial-partialtd">
                                     The input MUST be in <a>Partial TD</a> form and conform to the
-                                    original TD structure. 
-                                </span>
+                                    original TD structure.</span>
                                 
                                 If the input contains members that appear in the original TD, 
                                 their values are replaced. If a member does not appear in the 
@@ -1801,8 +1755,7 @@ img.wot-diagram {
                                 
                                 After applying the modifications, the TD object is validated in accordance with [[[#validation]]].
                                 <span class="rfc2119-assertion" id="tdd-things-update-partial-resp">
-                                    Upon success, the server MUST respond with a 204 (No Content) status.
-                                </span>
+                                    Upon success, the server MUST respond with a 204 (No Content) status.</span>
 
                                 <p>
                                     This operation is specified as `partiallyUpdateThing` property in 
@@ -1856,11 +1809,9 @@ img.wot-diagram {
                         <p>
                             <span class="rfc2119-assertion" id="tdd-things-delete">
                                 A delete operation MUST be done using an HTTP `DELETE` request
-                                at `/things/{id}`, where `id` is the identifier of the existing TD.
-                            </span>
+                                at `/things/{id}`, where `id` is the identifier of the existing TD.</span>
                             <span class="rfc2119-assertion" id="tdd-things-delete-resp">
-                                A successful response MUST have 204 (No Content) status.
-                            </span>
+                                A successful response MUST have 204 (No Content) status.</span>
                             The retrieve operation is specified as `deleteThing` property in
                             [[[#directory-api-spec]]].
                         </p>
@@ -1884,12 +1835,10 @@ img.wot-diagram {
                         <p>
                             <span class="rfc2119-assertion" id="tdd-things-list-method">
                                 The directory MUST allow retrieval of existing TDs using HTTP `GET` requests
-                                at the `/things` endpoint.
-                            </span>
+                                at the `/things` endpoint.</span>
                         
                             <span class="rfc2119-assertion" id="tdd-things-list-resp">
-                                A successful response MUST have 200 (OK) status and an array of TDs in the body.
-                            </span>
+                                A successful response MUST have 200 (OK) status and an array of TDs in the body.</span>
                             <span class="rfc2119-assertion" id="tdd-things-retrieve-resp-content-type">
                                 A successful response with JSON serialization MUST contain `application/json`
                                 or more specifically, `application/ld+json` in the Content-Type header.</span>
@@ -1906,32 +1855,27 @@ img.wot-diagram {
                             
                             <span class="rfc2119-assertion" id="tdd-things-list-pagination">
                                 The server MAY support pagination to return the collection
-                                in small subsets.
-                            </span>
+                                in small subsets.</span>
                             The pagination must be based on the following rules:
                             <ul>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-limit">
                                         When the `limit` query parameter is set to a positive integer,
                                         the server MAY respond with a subset of TDs totalling
-                                        to less than or equal to the requested number.
-                                    </span>
+                                        to less than or equal to the requested number.</span>
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-header-nextlink">
                                         When there are more TDs after a returned subset of the collection,
                                         the response MUST contain a `next` Link header [[RFC8288]]
-                                        with the URL of the next subset.
-                                    </span>
+                                        with the URL of the next subset.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-header-nextlink-attr">
                                         The `next` link MUST include all arguments needed to produce the same set of
-					data and its ordering, in particular the same `limit` argument
-					given on the initial request as well as a zero-based `offset` argument anchored
-					at the beginning of the next subset.
-                                    </span>
-				    <span class="rfc2119-assertion" id="tdd-things-list-pagination-header-nextlink-base">
-                                    	The link MUST be absolute or relative to directory API's base URL.
-			    	    </span>
+                                        data and its ordering, in particular the same `limit` argument
+                                        given on the initial request as well as a zero-based `offset` argument anchored
+                                        at the beginning of the next subset.</span>
+                                    <span class="rfc2119-assertion" id="tdd-things-list-pagination-header-nextlink-base">
+                                        The link MUST be absolute or relative to directory API's base URL.</span>
                                     Moreover, it may include additional arguments that are necessary for
                                     ordering or session management.
                                 </li>
@@ -1939,8 +1883,7 @@ img.wot-diagram {
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-header-canonicallink">
                                         All paged responses MUST contain a `canonical` Link header [[RFC8288]]
                                         pointing to the collection and include an `etag` parameter to represent
-                                        the current state of the collection.
-                                    </span>
+                                        the current state of the collection.</span>
                                     The link may be absolute or relative to directory API's base URL.
                                     The `etag` value could be a revision number, timestamp, or UUID Version 4,
                                     set whenever the TD collection changes in a way that affects the
@@ -1953,30 +1896,24 @@ img.wot-diagram {
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-default">
                                         By default, the collection MUST be sorted using UTF-8 lexicographical order
-                                        by the unique identifier of TDs.
-                                    </span>
+                                        by the unique identifier of TDs.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order">
                                         The server MAY support sorting by other TD attributes using
                                         query arguments: `sort_by` to select a field (e.g. `created`)
                                         and `sort_order` to choose the order
-                                        (i.e. `asc` or `desc` for ascending and descending ordering).
-                                    </span>
+                                        (i.e. `asc` or `desc` for ascending and descending ordering).</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">
                                         A server MUST reject requests to sort on fields that do not have 
                                         values that are orderable basic types, 
-                                        with a 400 (Bad Request) status.
-                                    </span>
+                                        with a 400 (Bad Request) status.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-unsupported">
                                         If the server does not support custom sorting,
-                                        it MUST reject the request with 501 (Not Implemented) status.
-                                    </span>
+                                        it MUST reject the request with 501 (Not Implemented) status.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-nextlink">
-                                        If sorting attributes are accepted, they MUST be added consistently to all `next` links.
-                                    </span>
+                                        If sorting attributes are accepted, they MUST be added consistently to all `next` links.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-utf-8">
                                         Sorting order MUST always be defined using lexicographical ordering on
-                                        a UTF-8 encoding of the relevant fields.
-                                    </span>
+                                        a UTF-8 encoding of the relevant fields.</span>
                                 </li>
                             </ul>
                             <p>
@@ -2042,8 +1979,7 @@ img.wot-diagram {
 				<span class="rfc2119-assertion" id="tdd-things-list-pagination-collection">
 					As an alternative to an array of TDs as the body of the response, the server MAY
 					send a more verbose payload allowing server-side information, such as pagination
-					information, to be included in addition to the actual data.
-				</span>
+					information, to be included in addition to the actual data.</span>
 			</p>
 
 			<p>
@@ -2092,13 +2028,11 @@ img.wot-diagram {
                         <p>
                            <span class="rfc2119-assertion" id="tdd-validation-syntactic">
                                 The syntactic validation of TD objects before storage is RECOMMENDED to
-                                prevent common erroneous submissions.
-                            </span>
+                                prevent common erroneous submissions.</span>
                             <span class="rfc2119-assertion" id="tdd-validation-jsonschema">
                                 The server MAY use
                                 <a href="https://www.w3.org/TR/wot-thing-description/#json-schema-for-validation">Thing Description JSON Schema</a>
-                                to validate standard TD vocabulary, or a more comprehensive JSON Schema to also validate extensions.
-                            </span>
+                                to validate standard TD vocabulary, or a more comprehensive JSON Schema to also validate extensions.</span>
                         </p>
                         <p>
                             Additional forms of validation can be added to support various use cases.
@@ -2108,23 +2042,19 @@ img.wot-diagram {
                         <p>
                             <span class="rfc2119-assertion" id="tdd-validation-result">
                                 If the server fails to validate the TD object, it MUST inform the client
-                                with necessary details to identify and resolve the errors.
-                            </span>
+                                with necessary details to identify and resolve the errors.</span>
     
                             <span class="rfc2119-assertion" id="tdd-validation-response">
                                 The validation error MUST be described as Problem Details [[RFC7807]]
                                 with an extension field called `validationErrors`, set to an array of objects
-                                with `field` and `description` fields.
-                            </span>
+                                with `field` and `description` fields.</span>
                             This is necessary to represent the error in a machine-readable way. 
                             <span class="rfc2119-assertion" id="tdd-validation-response-utf-8">
-                                All validation error responses described using Problem Details MUST be encoded using UTF-8.
-                            </span>
+                                All validation error responses described using Problem Details MUST be encoded using UTF-8.</span>
                             <span class="rfc2119-assertion" id="tdd-validation-response-lang">
                                 Validation error responses MAY report details in different languages using
                                 proactive negotiation, if the <code>Accept-Language</code> header field has been
-                                set in the HTTP request [[RFC7231]].
-                            </span>
+                                set in the HTTP request [[RFC7231]].</span>
                         </p>
                         
                         [[[#example-validation-error]]] is an example error response with two validation errors.
@@ -2165,24 +2095,21 @@ img.wot-diagram {
                         The Notification API is to notify clients about the changes
                         to <a>TDs</a> maintained within the directory.
                         <span class="rfc2119-assertion" id="tdd-notification">
-                            Directories MAY implement the Notification API.
-                        </span>
+                            Directories MAY implement the Notification API.</span>
                     </p>
                     <p>
                         
                         <span class="rfc2119-assertion" id="tdd-notification-sse">
                             The Notification API MUST follow the Server-Sent Events (SSE) [[EVENTSOURCE]]
                             specifications to serve events to clients
-                            at `/events` endpoint.
-                        </span>
+                            at `/events` endpoint.</span>
                         In particular, the server responds to successful requests with 200 (OK) status
                         and `text/event-stream` Content Type.
                         Re-connecting clients may continue from
                         the last event by providing the last event ID as `Last-Event-ID` header value.
                         <span class="rfc2119-assertion" id="tdd-notification-event-id">
                             The server SHOULD provide an event ID as the `id` field in each event
-                            and respond to re-connecting clients by delivering all missed events.
-                        </span>
+                            and respond to re-connecting clients by delivering all missed events.</span>
                     </p>
                     <p>
                         The rest of this section describes the implementation details on top of the SSE protocol.
@@ -2196,8 +2123,7 @@ img.wot-diagram {
                             <span class="rfc2119-assertion" id="tdd-notification-event-types">
                                 The server MUST produce events attributed to the lifecycle of 
                                 the Thing Descriptions within the directory using 
-                                `thing_created`, `thing_updated`, and `thing_deleted` event types.
-                            </span>
+                                `thing_created`, `thing_updated`, and `thing_deleted` event types.</span>
                         </dd>
 
                         <dt>Event Filtering</dt>
@@ -2210,8 +2136,7 @@ img.wot-diagram {
                             <p>
                                 <span class="rfc2119-assertion" id="tdd-notification-filter-type">
                                     The server MUST support event filtering based on the 
-                                    event type given by the client upon subscription. 
-                                </span>
+                                    event type given by the client upon subscription.</span>
                             </p>
                             <p>
                                 For example, given the URI Template `/events{/type}`:
@@ -2238,16 +2163,14 @@ img.wot-diagram {
                         <dt>Event Data</dt>
                         <dd>
                             <span class="rfc2119-assertion" id="tdd-notification-data">
-                                The event data MUST contain the JSON serialization of the event object.
-                            </span>
+                                The event data MUST contain the JSON serialization of the event object.</span>
                             The event data object is a <a>Partial TD</a> or the whole <a>TD</a> object
                             depending on the request:
                             <ul>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-td-id">
                                         The event data object MUST at least include the identifier of the
-                                        TD created, updated, or deleted at that event in <a>Partial TD</a> form.
-                                    </span>
+                                        TD created, updated, or deleted at that event in <a>Partial TD</a> form.</span>
 
                                     <aside class="example" title="Creation and deletion SSE events for a TD">
                                         <pre>
@@ -2264,8 +2187,7 @@ img.wot-diagram {
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-create-full">
                                         When `diff` query parameter is set to `true` and the event has `thing_created` type,
-                                        the server MAY return the whole TD object as event data.
-                                    </span>
+                                        the server MAY return the whole TD object as event data.</span>
                                     
                                     <aside class="example" id="example-create-event-full" title="Full creation SSE event for a TD">
                                         <pre>
@@ -2300,13 +2222,11 @@ img.wot-diagram {
                                     <span class="rfc2119-assertion" id="tdd-notification-data-update-diff">
                                         When `diff` query parameter is set to `true` and the event has `thing_updated` type,
                                         the server MAY inform the client about the updated parts following the
-                                        JSON Merge Patch [[RFC7396]] format.
-                                    </span>
+                                        JSON Merge Patch [[RFC7396]] format.</span>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-update-id">
                                         A `thing_updated` event data that is based on JSON Merge Patch [[RFC7396]]
                                         MUST always include the identifier of the TD regardless of whether it
-                                        is changed.
-                                    </span>
+                                        is changed.</span>
 
                                     <p>
                                         The following example shows the event triggered on update of the TD from [[[#example-create-event-full]]]:
@@ -2326,8 +2246,7 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-notification-data-delete-diff">
-                                        The `diff` query parameter MUST be ignored for `thing_deleted` events.
-                                    </span>
+                                        The `diff` query parameter MUST be ignored for `thing_deleted` events.</span>
                                     In other words, the server shall not include additional properties in
                                     the payload of `thing_deleted` events when `diff` is set to `true`. 
                                 </li>
@@ -2384,14 +2303,12 @@ img.wot-diagram {
                     This specification describes three search APIs: syntactic search with JSONPath [[?JSONPATH]],
                     syntactic search with XPath [[xpath-31]], and semantic search with SPARQL [[sparql11-overview]].
                     <span class="rfc2119-assertion" id="tdd-search-sparql">
-                        The Directory MAY implement semantic search with SPARQL.
-                    </span>
+                        The Directory MAY implement semantic search with SPARQL.</span>
                     JSONPath and XPath are informative and subject to change.
                     <p>
                         <span class="rfc2119-assertion" id="tdd-search-large-tdds">
                             It is RECOMMENDED that directories implement a search API
-                            to efficiently serve <a>TDs</a> based on client-specific queries.
-                        </span>
+                            to efficiently serve <a>TDs</a> based on client-specific queries.</span>
                     </p>
 
                     <section id="jsonpath-semantic" class="informative">
@@ -2435,35 +2352,27 @@ img.wot-diagram {
                         Support for SPARQL Search API is optional.
                         <span class="rfc2119-assertion" id="tdd-search-sparql-version">
                             If implemented, the SPARQL search API MUST allow searching TDs using
-                            the SPARQL 1.1 protocol [[sparql11-overview]].
-                        </span>
+                            the SPARQL 1.1 protocol [[sparql11-overview]].</span>
                         <span class="rfc2119-assertion" id="tdd-search-sparql-method-get">
                             The SPARQL API MUST accept queries using HTTP <code>GET</code> requests
-                            at `/search/sparql?query={query}` endpoint, where `query` is the SPARQL expression.
-                        </span>
+                            at `/search/sparql?query={query}` endpoint, where `query` is the SPARQL expression.</span>
                         <span class="rfc2119-assertion" id="tdd-search-sparql-method-post">
                             The support for SPARQL search using HTTP <code>POST</code> method
-                            at `/search/sparql` endpoint is OPTIONAL.
-                        </span>
+                            at `/search/sparql` endpoint is OPTIONAL.</span>
                         <span class="rfc2119-assertion" id="tdd-search-sparql-resp-select-ask">
-                            A successful request with a query <code>SELECT</code> or <code>ASK</code> MUST return a response 200 (OK) status, and contain <code>application/json</code> by default in the Content-Type header.
-                        </span>
-			 <span class="rfc2119-assertion" id="tdd-search-sparql-resp-describe-construct">
-                            A successful request with a query <code>CONSTRUCT</code> and <code>DESCRIBE</code> MUST return a response 200 (OK) status, and contain <code>application/ld+json</code> by default in the Content-Type header.
-			 </span>
-			<span class="rfc2119-assertion" id="tdd-search-sparql-error">
-			     A request with any query different from <code>SELECT</code>, <code>ASK</code>, <code>CONSTRUCT</code> or <code>DESCRIBE</code> MUST return a response 400 (Bad Request).
-			</span>
+                            A successful request with a query <code>SELECT</code> or <code>ASK</code> MUST return a response 200 (OK) status, and contain <code>application/json</code> by default in the Content-Type header.</span>
+			            <span class="rfc2119-assertion" id="tdd-search-sparql-resp-describe-construct">
+                            A successful request with a query <code>CONSTRUCT</code> and <code>DESCRIBE</code> MUST return a response 200 (OK) status, and contain <code>application/ld+json</code> by default in the Content-Type header.</span>
+                        <span class="rfc2119-assertion" id="tdd-search-sparql-error">
+                            A request with any query different from <code>SELECT</code>, <code>ASK</code>, <code>CONSTRUCT</code> or <code>DESCRIBE</code> MUST return a response 400 (Bad Request).</span>
                         The semantic search with SPARQL is specified as `searchSPARQL` action in
                         [[[#directory-api-spec]]].
                         
                         <span class="rfc2119-assertion" id="tdd-search-sparql-federation">
-                            A WoT Thing Description Directory MAY implement federation in its SPARQL query API.
-                        </span>
+                            A WoT Thing Description Directory MAY implement federation in its SPARQL query API.</span>
                         <span class="rfc2119-assertion" id="tdd-search-sparql-federation-version">
                             If implemented, the SPARQL API MUST implement the
-                            SPARQL 1.1 Federated Query standard [[sparql11-overview]].
-                        </span>
+                            SPARQL 1.1 Federated Query standard [[sparql11-overview]].</span>
                     </section>
                 </section>
 
@@ -2548,22 +2457,19 @@ img.wot-diagram {
                     <li>
 	            <span class="rfc2119-assertion" id="sec-tdd-throttle-queries">
                     A WoT Thing Description Directory implementation SHOULD
-		    limit the number of queries per unit time from the same requestor.
-		    </span>
+                    limit the number of queries per unit time from the same requestor.</span>
 		    </li>
                     <li>
 	            <span class="rfc2119-assertion" id="sec-tdd-limit-query-complexity">
                     A WoT Thing Description Directory implementation SHOULD
-		    limit the complexity of queries (for example, the total length of the query 
-                    expression or its depth).
-		    </span>
+		            limit the complexity of queries (for example, the total length of the query 
+                    expression or its depth).</span>
 		    </li>
                     <li>
 	            <span class="rfc2119-assertion" id="sec-tdd-query-watchdog">
                     A WoT Thing Description Directory implementation SHOULD
-	            use a watchdog timer to abort queries that take more than
-                    a certain maximum (implementation-configurable) amount of time.
-		    </span>
+	                use a watchdog timer to abort queries that take more than
+                    a certain maximum (implementation-configurable) amount of time.</span>
 		    </li> 
                     </ul>
                     </dd>
@@ -2606,19 +2512,16 @@ img.wot-diagram {
 		<li>
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-no-observe">
                 Open implementations of Introduction mechanisms SHOULD NOT
-		support observe or similar extended result subprotocols.
-		</span>
+		support observe or similar extended result subprotocols.</span>
 		</li>
 		<li>
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-no-multicast">
 		Open implementations of Introduction mechanisms SHOULD NOT respond to multicast
-		requests unless this is absolutely required by the protocol.
-		</span>
+		requests unless this is absolutely required by the protocol.</span>
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-if-multicast-required">
 		If support for multicast is required,
 		in the case of CoAP, the recommendations made in [[RFC9175]] SHOULD be
-		applied.
-		</span>
+		applied.</span>
 		Note however that in the case of discovery the number of servers that
 		might respond to a multicast request will generally not be known in
 		advance, in which case the mitigations proposed in [[RFC9175]] may
@@ -2629,22 +2532,19 @@ img.wot-diagram {
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-limit-response-size">
 		The total size of responses to an Introduction SHOULD
 		be less than 3x the size of the total size of request, and this should 
-		include any error responses.
-		</span>
+		include any error responses.</span>
 		This is consistent with DDOS mitigations in [[RFC9000]] (QUIC) and HTTP/3.
 		Here "total size" includes any headers required by the protocol itself.
 		</li>
 		<li>
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-throttling">
 		Introductions SHOULD rate-limit responses to any particular
-		request source.
-		</span>
+		request source.</span>
 		</li>
 		<li>
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-no-ext">
 		Introduction mechanisms on a segmented network behind a firewall
-		(e.g. a LAN) SHOULD NOT respond to requests that are (apparently) from outside that LAN.
-		</span>
+		(e.g. a LAN) SHOULD NOT respond to requests that are (apparently) from outside that LAN.</span>
 		</li>
 	        </ul>
 		Of particular concern are Introduction mechanisms that can
@@ -2685,8 +2585,7 @@ img.wot-diagram {
 		<p>
 	        <span class="rfc2119-assertion" id="sec-self-psk">
                 PSK (pre-shared keys) SHOULD be used if possible on LANs, 
-		meaning one of the ciphersuites in [[RFC4279]].
-		</span>
+		meaning one of the ciphersuites in [[RFC4279]].</span>
                 This does require that Things are assigned PSKs in a common security domain, 
 		which is typically done by following an onboarding process.  
 		Unfortunately, specific onboarding processes 
@@ -2702,8 +2601,7 @@ img.wot-diagram {
 		If Things cannot be individually secured with transport security and 
 		authentication and authorization,
 		a separate network SHOULD be set up, i.e. with an alternative SSID, and used only
-		for IoT devices.
-		</span>
+		for IoT devices.</span>
 		Using a segmented network reduces the need for distributing the password
                 to this network to those who need access to the set of IoT devices connected to it.
 		</p>
@@ -2724,8 +2622,7 @@ img.wot-diagram {
 		If Things cannot be individually secured with transport security and 
 		authentication and authorization,
                 then they MAY be made available for general access via a proxy
-		that can provide suitable access controls.
-		</span>
+		that can provide suitable access controls.</span>
                 </dd>
             </dl>
         </section>
@@ -2840,8 +2737,7 @@ img.wot-diagram {
                 <li>
 	        <span class="rfc2119-assertion" id="priv-loc-disable-public-directories">
 		To avoid location tracking, a WoT Thing MAY 
-		disable registration with public directories.
-		</span>
+		disable registration with public directories.</span>
 		Registration would still be possible with 
                 personal directories, for example, a home gateway, but a user could disable registration at other
                 locations.  This has the disadvantage that functionality is lost: personal devices cannot be
@@ -2851,8 +2747,7 @@ img.wot-diagram {
 		<li>
 	        <span class="rfc2119-assertion" id="priv-loc-anonymous-tds">
 		To avoid location tracking, a WoT Thing MAY 
-		use Anonymous TDs.  
-		</span>
+		use Anonymous TDs.</span>
 		In some cases, it may be possible to use
 		anonymous TDs and omit explicit IDs from TDs submitted to
 		a TDD.  In this case the TDD will generate a local ID valid
@@ -2864,8 +2759,7 @@ img.wot-diagram {
                 <li>
 	        <span class="rfc2119-assertion" id="priv-loc-gen-ids">
 		To avoid location tracking, a WoT Thing MAY 
-		periodically generate new IDs.  
-		</span>
+		periodically generate new IDs.</span>
 		Using fixed IDs makes it exceptionally easy to track devices.  This problem
                 also occurs in DHCP with MAC address and there is a similar partial mitigation: 
                 generate new random IDs periodically.
@@ -2886,8 +2780,7 @@ img.wot-diagram {
                 <li>
 	        <span class="rfc2119-assertion" id="priv-loc-gen-ids">
 		To reduce the risk of negative location inferencing, access to 
-                private directories SHOULD be limited by using access controls.  
-		</span>
+                private directories SHOULD be limited by using access controls.</span>
 		If an attacker cannot access the service,
                 they cannot retrieve information to infer location.  
 		Access rights provided to guests (e.g. for Peer-to-Peer Personal scenarios)
@@ -2902,12 +2795,10 @@ img.wot-diagram {
 	        <span class="rfc2119-assertion" id="priv-loc-explicit-care">
 		When explicit location information is available, whether stored in a TD or available in a property,
                 additional care SHOULD be taken to only share the TD and/or access to the device with trusted partners,
-                including directories.  
-		</span>
+                including directories.</span>
 	        <span class="rfc2119-assertion" id="priv-loc-explicit-strip">
 		If the TD must be shared with a public directory, the location information MAY be
-                stripped.
-		</span>
+                stripped.</span>
                 </ul>
                 </dd>
             </dl>
@@ -2926,8 +2817,7 @@ img.wot-diagram {
                 <dd>
 	        <span class="rfc2119-assertion" id="priv-query-anon">
                 When accessing a public directory, like any other public web service,
-                users and implementations SHOULD use an anonymous identity provider.
-		</span>
+                users and implementations SHOULD use an anonymous identity provider.</span>
                 In particular, OAuth2 can provide tokens which don't identify specific individuals,
                 they just assert access rights proven elsewhere.
                 </dd>


### PR DESCRIPTION
Adding a line break at the end of assertion blocks is rendered as a extra whitespace at the end of the assertion. This leads to readability issues in the output. For example, the following ~two~ three assertions appear as one:

Before:
![image](https://user-images.githubusercontent.com/11150423/173386935-e9851aa6-6b6c-4518-aa23-d9fa5c169a1d.png)

After: 
![image](https://user-images.githubusercontent.com/11150423/173394158-cc2c3d0f-db49-4919-8631-8a82556f85e1.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-discovery/pull/343.html" title="Last updated on Jun 13, 2022, 3:53 PM UTC (21d7f48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/343/c7bac4d...farshidtz:21d7f48.html" title="Last updated on Jun 13, 2022, 3:53 PM UTC (21d7f48)">Diff</a>