### PR TITLE
Get rid of dangling colon in Ontology

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,8 +769,11 @@ img.wot-diagram {
                 </p>
 
                 <p>
-                    Moreover, the Discovery ontology defines two new Thing Description classes
-                    that may be used to model special exploratory metadata:
+                    The Discovery ontology also defines two new Thing Description classes,
+                    described in the following sections,
+                    that may be used to model special exploratory metadata: 
+                    <a href="#exploration-td-type-thingdirectory">ThingDirectory</a> and 
+                    <a href="#exploration-td-type-thinglink">ThingLink</a>.
                 </p>
 
                 <section id="exploration-td-type-thingdirectory" class="normative">


### PR DESCRIPTION
The end of the ontology introductory section used to have a sentence starting with "Moreover" and ending in a colon.  It was actually referring to the next two subsections but was a little weird; it looked like part of the content was missing.  I rephrased it to be a complete sentence, now referring to the two ontology vocabulary terms by name.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/347.html" title="Last updated on Jun 14, 2022, 5:01 PM UTC (deffd90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/347/a3ab94c...mmccool:deffd90.html" title="Last updated on Jun 14, 2022, 5:01 PM UTC (deffd90)">Diff</a>