### PR TITLE
Not all directories are self-describing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1142,7 +1142,7 @@ img.wot-diagram {
         <section id="exploration-directory" class="normative">
             <h2>Thing Description Directory</h2>
             <p>
-             A <a>Thing Description Directory</a> (TDD or Directory for short) is a self-describing
+             A <a>Thing Description Directory</a> (TDD or Directory for short) is a 
              <a>Thing</a> that provides a service to manage a set of TDs describing other Things.
             </p>
 


### PR DESCRIPTION
Intro to directories included the statement that directories were "self-describing Things."  This PR removes the word "self-describing" since the updated class model allows for directories that are not self-describing, although they are always Things.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/349.html" title="Last updated on Jun 14, 2022, 5:20 PM UTC (4e81330)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/349/a3ab94c...mmccool:4e81330.html" title="Last updated on Jun 14, 2022, 5:20 PM UTC (4e81330)">Diff</a>