### PR TITLE
Remove reference to issue 86

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -277,7 +277,7 @@
             ]
         },
         "searchJSONPath": {
-            "description": "JSONPath syntactic search",
+            "description": "JSONPath syntactic search.  This affordance is not normative and is provided for information only.",
             "uriVariables": {
                 "query": {
                     "title": "A valid JSONPath expression",
@@ -310,7 +310,7 @@
             ]
         },
         "searchXPath": {
-            "description": "XPath syntactic search",
+            "description": "XPath syntactic search.  This affordance is not normative and is provided for information only.",
             "uriVariables": {
                 "query": {
                     "title": "A valid XPath expression",

--- a/index.html
+++ b/index.html
@@ -2379,26 +2379,14 @@ img.wot-diagram {
 
                 <section id="directory-api-spec">
                     <h4>API Specification (Thing Model)</h1>
-
-                    <p class="issue" data-number="86">
-                        To do: add a
-                        <a href="https://w3c.github.io/wot-thing-description/#thing-model">Thing Model</a>
-                        (`directory.tm.json`)
-                        that can derive to
-                        <a href="https://github.com/w3c/wot-discovery/blob/main/implementations/example-directory-oauth2.td.json">this TD</a>
-                        as an example.
-                        The <a>TM</a> should describe all interaction affordances and indicate which ones
-                        are required (i.e. mandatory by this spec). Moreover, it should use placeholders
-                        for deployment-specific attributes.
-                        Informative affordances (JSONPath and XPath) should be defined as such.
-                    </p>
-
-                    The API of the directory is specified as a <a>Thing Model</a>.
+                    <p>
+                    A template for the API of Thing Description Directories is given here
+                    as a <a>Thing Model</a>.
                     The Thing Model alone should not be considered as the reference
                     to implement or interact with a directory.
                     The full specification is available as human-readable text 
                     in [[[#exploration-directory-api]]].
-
+                    </p>
                     <pre class="advisement json">
                         <div data-include='directory.tm.json'></div>
                     </pre>

--- a/index.html
+++ b/index.html
@@ -2382,10 +2382,15 @@ img.wot-diagram {
                     <p>
                     A template for the API of Thing Description Directories is given here
                     as a <a>Thing Model</a>.
-                    The Thing Model alone should not be considered as the reference
-                    to implement or interact with a directory.
-                    The full specification is available as human-readable text 
+                    The Thing Model is normative (except where noted) but should not be considered 
+                    as the sole reference to implement or interact with a Thing Description Directory.
+                    Please refer also to the specifications given 
                     in [[[#exploration-directory-api]]].
+                    </p>
+                    <p>
+                    The <code>searchJSONPath</code> and <code>searchXPath</code> affordances 
+                    given in this Thing Model
+                    are not normative and are provided for information only.
                     </p>
                     <pre class="advisement json">
                         <div data-include='directory.tm.json'></div>


### PR DESCRIPTION
Resolves #86 

There was an old reference to issue #86 which basically said "we should use a Thing Model".  Well, we ARE using a Thing Model now, so I closed issue 86 and removed the reference to it in the text.  I also added some missing markup in the intro paragraph and tweaked the opening sentence again to make it clearer (I hope) that the TM applies to Thing Description Directories as a class.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/350.html" title="Last updated on Jun 20, 2022, 2:20 PM UTC (88d50f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/350/a3ab94c...mmccool:88d50f5.html" title="Last updated on Jun 20, 2022, 2:20 PM UTC (88d50f5)">Diff</a>