### PR TITLE
Fix Duplicate IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2775,7 +2775,7 @@ img.wot-diagram {
 		to mitigate tracking.  In the context of ipv6 [[RFC8981]] discusses this.
                 </li>
                 <li>
-	        <span class="rfc2119-assertion" id="priv-loc-gen-ids">
+	        <span class="rfc2119-assertion" id="priv-loc-priv-dir-access">
 		To reduce the risk of negative location inferencing, access to 
                 private directories SHOULD be limited by using access controls.</span>
 		If an attacker cannot access the service,

--- a/index.html
+++ b/index.html
@@ -1843,7 +1843,7 @@ img.wot-diagram {
                         
                             <span class="rfc2119-assertion" id="tdd-things-list-resp">
                                 A successful response MUST have 200 (OK) status and an array of TDs in the body.</span>
-                            <span class="rfc2119-assertion" id="tdd-things-retrieve-resp-content-type">
+                            <span class="rfc2119-assertion" id="tdd-things-list-resp-content-type">
                                 A successful response with JSON serialization MUST contain `application/json`
                                 or more specifically, `application/ld+json` in the Content-Type header.</span>
                             Note that the default serialization is JSON with JSON-LD syntax,


### PR DESCRIPTION
Resolves a couple of duplicate ids.  Since this is invisible and editorial, I intend to merge this PR immediately.  However it introduces two new ids, tdd-things-list-resp-content-type and priv-loc-priv-dir-access, which were previously duplicates.  So this means that test files, etc. need to be updated to include these two new assertion ids.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/358.html" title="Last updated on Jun 24, 2022, 5:58 PM UTC (06a5d9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/358/15cfbf8...mmccool:06a5d9f.html" title="Last updated on Jun 24, 2022, 5:58 PM UTC (06a5d9f)">Diff</a>