### PR TITLE
feat: allow Content-Format 50 for CoAP in TD Server

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,7 +1106,8 @@ img.wot-diagram {
                     <span class="rfc2119-assertion" id="exploration-server-coap-resp">
                         A successful response from a CoAP-based TD Server providing a <a>TD</a>
                         MUST have a 2.05 (Content) status, contain a Content-Format option
-                        with value 432 (`application/td+json`), and the <a>TD</a> in the payload.</span>
+                        with value 50 (`application/json`) or 432 (`application/td+json`), 
+                        and the <a>TD</a> in the payload.</span>
                     Note that the payload might be split over multiple message exchanges using
                     block-wise transfer [[RFC7959]].
                     <span class="rfc2119-assertion" id="exploration-server-coap-alternate-content">


### PR DESCRIPTION
Resolves #365


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/370.html" title="Last updated on Jul 4, 2022, 12:22 PM UTC (1bd2305)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/370/7c5ad7d...JKRhb:1bd2305.html" title="Last updated on Jul 4, 2022, 12:22 PM UTC (1bd2305)">Diff</a>