### PR TITLE
editorial: Remove extra word in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1902,7 +1902,7 @@ img.wot-diagram {
                                     The clients may rely on the `etag` value to know whether the collection
                                     remains consistent across paginated retrieval of the collection.
                                     For example, creation or deletion of TDs or update of TD fields used for
-                                    ordering may make shift the calculated paging window.
+                                    ordering may shift the calculated paging window.
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-default">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/w3c-wot-discovery/pull/408.html" title="Last updated on Sep 5, 2022, 8:55 AM UTC (d684baf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/408/98fd1c0...farshidtz:d684baf.html" title="Last updated on Sep 5, 2022, 8:55 AM UTC (d684baf)">Diff</a>