### PR TITLE
Replace CoRE RD draft with RFC 9176

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,19 +89,6 @@
                 , publisher: "IETF"
                 , date: "11 May 2020"
             },
-            "CoRE-RD" : {
-                  title: "CoRE Resource Directory"
-                , href: "https://tools.ietf.org/html/draft-ietf-core-resource-directory-26"
-                , authors: [
-                    "Christian Amsüss"
-                  , "Zach Shelby"
-                  , "Michael Koster"
-                  , "Carsten Bormann"
-                  , "Peter van der Stok"
-                  ]
-                , publisher: "IETF"
-                , date: "2 November 2020"
-            },
             "JSONPATH": {
                 title: "JSONPath: Query expressions for JSON"
                 , href: "https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base"
@@ -672,7 +659,7 @@ img.wot-diagram {
                 <span class="rfc2119-assertion" id="introduction-core-rd">A Thing or <a>Thing Description Directory</a> MAY advertise its presence using the
                 Constrained RESTful Environment (CoRE) Link Format [[RFC6690]].</span>
                 <span class="rfc2119-assertion" id="introduction-core-rd-directory">
-                A <a>Thing</a> or <a>Thing Description Directory</a> MAY use the CoRE Resource Directory [[CoRE-RD]]
+                A <a>Thing</a> or <a>Thing Description Directory</a> MAY use the CoRE Resource Directory [[RFC9176]]
                 to register a link to its corresponding Thing Description.</span>
             </p>
             <p>

--- a/references.md
+++ b/references.md
@@ -6,7 +6,7 @@
 * [ACE-OAuth2: Authentication and Authorization for Constrained Environments (ACE) using the OAuth 2.0 Framework](https://datatracker.ietf.org/doc/draft-ietf-ace-oauth-authz/)
 * [CoAP (RFC7252): The Constrained Application Protocol](https://datatracker.ietf.org/doc/rfc7252/)
 * [CoRE-Link (RFC6690): Constrained RESTful Environments (CoRE) Link Format](https://datatracker.ietf.org/doc/rfc6690/)
-* [CoRE-RD: CoRE Resource Directory](https://datatracker.ietf.org/doc/draft-ietf-core-resource-directory/)
+* [CoRE-RD (RFC9176): CoRE Resource Directory](https://datatracker.ietf.org/doc/rfc9176/)
 * [HTTP1.1 (RFC2616): Hypertext Transfer Protocol -- HTTP/1.1](https://datatracker.ietf.org/doc/rfc2616/)
 * [WoT-TD: W3C Web of Things (WoT) Thing Description](https://www.w3.org/TR/wot-thing-description/)
 * [RFC2119: Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/rfc2119/)


### PR DESCRIPTION
I noticed that in the current draft version, the last CoRE RD draft is still cited instead of the RFC. This PR updates the citation accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/411.html" title="Last updated on Sep 26, 2022, 6:36 AM UTC (6aa6ab6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/411/299e2f3...JKRhb:6aa6ab6.html" title="Last updated on Sep 26, 2022, 6:36 AM UTC (6aa6ab6)">Diff</a>