### PR TITLE
Add tdd-things-create-anonymous-id to manual tests

### DIFF
--- a/testing/manual.csv
+++ b/testing/manual.csv
@@ -79,6 +79,7 @@
 "tdd-search-sparql-federation-version","null",
 "tdd-search-sparql-resp-describe-construct","null",
 "tdd-search-sparql-version","null",
+"tdd-things-create-anonymous-id","null",
 "tdd-things-create-known-contenttype","null",
 "tdd-things-update-contenttype","null",
 "tdd-things-list-pagination","null",


### PR DESCRIPTION
This is a relatively new assertion which is mostly informational and not directly testable from outside the directory:
> The directory MUST assign a local identifier to any Anonymous TD to enable local management and retrieval from the directory.

There are other assertions that specifically prescribe the ID format and the response from the directory which are testable.