### PR TITLE
Mark Size2 assertion as "pass" for RIOT WoT implementation

### DIFF
--- a/testing/inputs/results/riot-wot.csv
+++ b/testing/inputs/results/riot-wot.csv
@@ -16,7 +16,7 @@
 "exploration-server-coap-alternate-content","pass",
 "exploration-server-coap-method","pass",
 "exploration-server-coap-resp","pass",
-"exploration-server-coap-size2","fail",
+"exploration-server-coap-size2","pass",
 "sec-tdd-intro-no-observe","pass",
 "sec-tdd-intro-limit-response-size","null",
 "introduction-core-rd","pass",


### PR DESCRIPTION
This is a small change that hasn't been copied over from the wot-testing repo (see https://github.com/w3c/wot-testing/pull/472).