### PR TITLE
Add workaround for mandatory response contentType

### DIFF
--- a/index.html
+++ b/index.html
@@ -2453,6 +2453,15 @@ img.wot-diagram {
                     given in this Thing Model
                     are not normative and are provided for information only.
                     </p>
+                    <p>
+                        Note that a <code>contentType</code> is required by the WoT TD 1.1
+                        specification [[wot-thing-description11]] for instances of the
+                        <code>ExpectedResponse</code> class (i.e., the JSON object
+                        corresponding to the key <code>response</code> in a form),
+                        even when the body of the HTTP response is supposed to be empty.
+                        In this case, <code>application/octet-stream</code> can be used to
+                        ensure that the TD generated from the TM below is valid.
+                    </p>
                     <pre class="advisement json"
                          data-include='directory.tm.json'></pre>
 

--- a/index.html
+++ b/index.html
@@ -2459,7 +2459,7 @@ img.wot-diagram {
                         <code>ExpectedResponse</code> class (i.e., the JSON object
                         corresponding to the key <code>response</code> in a form),
                         even when the body of the HTTP response is supposed to be empty.
-                        In this case, <code>application/octet-stream</code> can be used to
+                        In this case, <code>application/x-empty</code> can be used to
                         ensure that the TD generated from the TM below is valid.
                     </p>
                     <pre class="advisement json"


### PR DESCRIPTION
Resolves #465.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/469.html" title="Last updated on Apr 3, 2023, 2:31 PM UTC (8547b40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/469/02b49fa...JKRhb:8547b40.html" title="Last updated on Apr 3, 2023, 2:31 PM UTC (8547b40)">Diff</a>