### PR TITLE
Rework RFC 9175 assertion and make it informative

### DIFF
--- a/index.html
+++ b/index.html
@@ -2620,14 +2620,10 @@ img.wot-diagram {
 	        <span class="rfc2119-assertion" id="sec-tdd-intro-no-multicast">
 		Open implementations of Introduction mechanisms SHOULD NOT respond to multicast
 		requests unless this is absolutely required by the protocol.</span>
-	        <span class="rfc2119-assertion" id="sec-tdd-intro-if-multicast-required">
 		If support for multicast is required,
-		in the case of CoAP, the recommendations made in [[RFC9175]] SHOULD be
-		applied.</span>
-		Note however that in the case of discovery the number of servers that
-		might respond to a multicast request will generally not be known in
-		advance, in which case the mitigations proposed in [[RFC9175]] may
-		not be effective.
+		in the case of CoAP, the observations made in [[AMPLIFICATION-ATTACKS]] are relevant,
+		since the number of servers that might respond to a multicast request during
+		discovery will generally not be known in advance.
 		</li>
 		<li>
 		Limit the size of responses to the minimum.  


### PR DESCRIPTION
This PR resolves #466, by changing the cited reference from RFC 9175 to `draft-irtf-t2trg-amplification-attacks` (which is the document that should have been cited in the first place) and "downgrading" the statement from normative to informative. The PR also fixes the actual content of the statement, since the cited document does not make any real recommendations regarding the use of CoAP with multicast; instead, it mostly states that 

> [f]or multicast requests, anti-amplification limits and the Echo Option do not really work unless the number of servers sending responses is known. Even if the responses have the same size as the request, the amplification factor from m servers is m, where m is typically unknown.

However, I am not sure if Group OSCORE could be a potential solution here or rather if the authors are implying that it could be one (CC @j1y3p4rk). In any case, though, this PR should already fix the main issue that is currently present in this part of the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/470.html" title="Last updated on Mar 28, 2023, 5:42 PM UTC (b4678b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/470/209c083...JKRhb:b4678b9.html" title="Last updated on Mar 28, 2023, 5:42 PM UTC (b4678b9)">Diff</a>