### PR TITLE
Update context URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2082,7 +2082,7 @@ img.wot-diagram {
 					title="Alternative payload format including pagination information">
 					<pre>
 						{
-							"@context": "https://www.w3.org/2022/wot/discovery/tdd",
+							"@context": "https://www.w3.org/2022/wot/discovery",
 							"@type": "ThingCollection",
 							"total": 12,
 							"members": [

--- a/index.html
+++ b/index.html
@@ -699,7 +699,7 @@ img.wot-diagram {
             </p>
             <p><span class="rfc2119-assertion" id="introduction-did-service-context">In order to define Service Endpoints
                 for WoT Discovery, the DID Document obtained by resolving the DID of a <a>Thing</a> or <a>Thing Description Directory</a>
-                MUST include the URL <code>https://www.w3.org/2021/wot/discovery/did</code> in its <code>@context</code> 
+                MUST include the URL <code>https://www.w3.org/2022/wot/discovery/did</code> in its <code>@context</code> 
                 [[did-spec-registries]].
             </span>
             </p>
@@ -717,7 +717,7 @@ img.wot-diagram {
                     {
                         "@context":[
                             "https://www.w3.org/ns/did/v1",
-                            "https://www.w3.org/2021/wot/discovery/did"
+                            "https://www.w3.org/2022/wot/discovery/did"
                         ],
                         ...
                         "service": [{
@@ -735,7 +735,7 @@ img.wot-diagram {
                     {
                         "@context":[
                             "https://www.w3.org/ns/did/v1",
-                            "https://www.w3.org/2021/wot/discovery/did"
+                            "https://www.w3.org/2022/wot/discovery/did"
                         ],
                         ...
                         "service": [{
@@ -833,7 +833,7 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-directory-description-type"> 
                         A TD which describes a Thing Description Directory instance MUST use type `ThingDirectory` from the
-                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingDirectory`.</span>
+                        discovery context or URI `https://www.w3.org/2022/wot/discovery/tdd#ThingDirectory`.</span>
                     <p>
                         A TD of this class can be derived from Directory's Thing Model; see [[[#directory-api-spec]]].
                     </p>
@@ -847,7 +847,7 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-link-description-type"> 
                         A TD which describes a reference to another TD MUST use type `ThingLink` from the
-                        discovery context or URI `https://www.w3.org/2021/wot/discovery#ThingLink`.</span>
+                        discovery context or URI `https://www.w3.org/2022/wot/discovery/tdd#ThingLink`.</span>
                     <span class="rfc2119-assertion" id="exploration-link-description-link"> 
                         A Thing Link MUST define the referenced TD as a Link with
                         `describedby` link relation type, `application/td+json` media type
@@ -862,8 +862,8 @@ img.wot-diagram {
                         <pre>
                             {
                                 "@context": [
-                                    "http://www.w3.org/ns/td",
-                                    "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+                                    "https://www.w3.org/2022/wot/td/v1.1",
+                                    "https://www.w3.org/2022/wot/discovery/tdd"
                                 ],
                                 "@type": "ThingLink",
                                 "id": "urn:example:link",
@@ -1227,7 +1227,7 @@ img.wot-diagram {
                     use within <a>TDs</a> that embed or reference the Discovery context. 
                     Note that only an <a>Enriched TD</a> embeds the registration information. 
 		            <span class="rfc2119-assertion" id="tdd-context-injection">An <a>Enriched TD</a>
-                        MUST contain in its @context the URI <code>https://w3c.github.io/wot-discovery/context/discovery-context.jsonld</code>.</span>
+                        MUST contain in its @context the URI <code>https://www.w3.org/2022/wot/discovery/tdd</code>.</span>
                     In this table,
                     client refers to the producer or consumer of a <a>TD</a> and server refers to
                     the <a>Thing Description Directory</a>.
@@ -1683,8 +1683,8 @@ img.wot-diagram {
                                 <pre>
                                     {
                                         "@context": [
-                                            "http://www.w3.org/ns/td",
-                                            "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+                                            "https://www.w3.org/2022/wot/td/v1.1",
+                                            "https://www.w3.org/2022/wot/discovery/tdd"
                                         ],
                                         "id": "urn:example:simple-td",
                                         "security": "basic_sc",
@@ -1717,8 +1717,8 @@ img.wot-diagram {
                                 <pre>
                                     {
                                         "@context": [
-                                            "http://www.w3.org/ns/td",
-                                            "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+                                            "https://www.w3.org/2022/wot/td/v1.1",
+                                            "https://www.w3.org/2022/wot/discovery/tdd"
                                         ],
                                         "id": "urn:uuid:48951ff3-4019-4e67-b217-dbbf011873dc",
                                         "security": "basic_sc",
@@ -1749,8 +1749,8 @@ img.wot-diagram {
                                 <pre>
                                     {
                                         "@context": [
-                                            "http://www.w3.org/ns/td",
-                                            "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+                                            "https://www.w3.org/2022/wot/td/v1.1",
+                                            "https://www.w3.org/2022/wot/discovery/tdd"
                                         ],
                                         "id": "urn:example:expirable-td",
                                         "security": "basic_sc",
@@ -2082,7 +2082,7 @@ img.wot-diagram {
 					title="Alternative payload format including pagination information">
 					<pre>
 						{
-							"@context": "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld",
+							"@context": "https://www.w3.org/2022/wot/discovery/tdd",
 							"@type": "ThingCollection",
 							"total": 12,
 							"members": [
@@ -2289,8 +2289,8 @@ img.wot-diagram {
                                             event: thing_created
                                             data: {
                                             data:     "@context": [
-                                            data:         "https://www.w3.org/2019/wot/td/v1",
-                                            data:         "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+                                            data:         "https://www.w3.org/2022/wot/td/v1.1",
+                                            data:         "https://www.w3.org/2022/wot/discovery/tdd"
                                             data:     ],
                                             data:     "description": "This is a new TD",
                                             data:     "id": "urn:example:simple-td",

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@ img.wot-diagram {
                     use within <a>TDs</a> that embed or reference the Discovery context. 
                     Note that only an <a>Enriched TD</a> embeds the registration information. 
 		            <span class="rfc2119-assertion" id="tdd-context-injection">An <a>Enriched TD</a>
-                        MUST contain in its @context the URI <code>https://www.w3.org/2022/wot/discovery/tdd</code>.</span>
+                        MUST contain in its @context the URI <code>https://www.w3.org/2022/wot/discovery</code>.</span>
                     In this table,
                     client refers to the producer or consumer of a <a>TD</a> and server refers to
                     the <a>Thing Description Directory</a>.

--- a/index.html
+++ b/index.html
@@ -1718,7 +1718,7 @@ img.wot-diagram {
                                     {
                                         "@context": [
                                             "https://www.w3.org/2022/wot/td/v1.1",
-                                            "https://www.w3.org/2022/wot/discovery/tdd"
+                                            "https://www.w3.org/2022/wot/discovery"
                                         ],
                                         "id": "urn:uuid:48951ff3-4019-4e67-b217-dbbf011873dc",
                                         "security": "basic_sc",

--- a/index.html
+++ b/index.html
@@ -717,7 +717,7 @@ img.wot-diagram {
                     {
                         "@context":[
                             "https://www.w3.org/ns/did/v1",
-                            "https://www.w3.org/2022/wot/discovery/did"
+                            "https://www.w3.org/2022/wot/discovery-did"
                         ],
                         ...
                         "service": [{

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@ img.wot-diagram {
                     {
                         "@context":[
                             "https://www.w3.org/ns/did/v1",
-                            "https://www.w3.org/2022/wot/discovery/did"
+                            "https://www.w3.org/2022/wot/discovery-did"
                         ],
                         ...
                         "service": [{

--- a/index.html
+++ b/index.html
@@ -1684,7 +1684,7 @@ img.wot-diagram {
                                     {
                                         "@context": [
                                             "https://www.w3.org/2022/wot/td/v1.1",
-                                            "https://www.w3.org/2022/wot/discovery/tdd"
+                                            "https://www.w3.org/2022/wot/discovery"
                                         ],
                                         "id": "urn:example:simple-td",
                                         "security": "basic_sc",

--- a/index.html
+++ b/index.html
@@ -699,7 +699,7 @@ img.wot-diagram {
             </p>
             <p><span class="rfc2119-assertion" id="introduction-did-service-context">In order to define Service Endpoints
                 for WoT Discovery, the DID Document obtained by resolving the DID of a <a>Thing</a> or <a>Thing Description Directory</a>
-                MUST include the URL <code>https://www.w3.org/2022/wot/discovery/did</code> in its <code>@context</code> 
+                MUST include the URL <code>https://www.w3.org/2022/wot/discovery-did</code> in its <code>@context</code> 
                 [[did-spec-registries]].
             </span>
             </p>

--- a/index.html
+++ b/index.html
@@ -833,7 +833,7 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-directory-description-type"> 
                         A TD which describes a Thing Description Directory instance MUST use type `ThingDirectory` from the
-                        discovery context or URI `https://www.w3.org/2022/wot/discovery/tdd#ThingDirectory`.</span>
+                        discovery context or URI `https://www.w3.org/2022/wot/discovery#ThingDirectory`.</span>
                     <p>
                         A TD of this class can be derived from Directory's Thing Model; see [[[#directory-api-spec]]].
                     </p>

--- a/index.html
+++ b/index.html
@@ -847,7 +847,7 @@ img.wot-diagram {
 
                     <span class="rfc2119-assertion" id="exploration-link-description-type"> 
                         A TD which describes a reference to another TD MUST use type `ThingLink` from the
-                        discovery context or URI `https://www.w3.org/2022/wot/discovery/tdd#ThingLink`.</span>
+                        discovery context or URI `https://www.w3.org/2022/wot/discovery#ThingLink`.</span>
                     <span class="rfc2119-assertion" id="exploration-link-description-link"> 
                         A Thing Link MUST define the referenced TD as a Link with
                         `describedby` link relation type, `application/td+json` media type

--- a/index.html
+++ b/index.html
@@ -863,7 +863,7 @@ img.wot-diagram {
                             {
                                 "@context": [
                                     "https://www.w3.org/2022/wot/td/v1.1",
-                                    "https://www.w3.org/2022/wot/discovery/tdd"
+                                    "https://www.w3.org/2022/wot/discovery"
                                 ],
                                 "@type": "ThingLink",
                                 "id": "urn:example:link",

--- a/index.html
+++ b/index.html
@@ -1750,7 +1750,7 @@ img.wot-diagram {
                                     {
                                         "@context": [
                                             "https://www.w3.org/2022/wot/td/v1.1",
-                                            "https://www.w3.org/2022/wot/discovery/tdd"
+                                            "https://www.w3.org/2022/wot/discovery"
                                         ],
                                         "id": "urn:example:expirable-td",
                                         "security": "basic_sc",

--- a/index.html
+++ b/index.html
@@ -2290,7 +2290,7 @@ img.wot-diagram {
                                             data: {
                                             data:     "@context": [
                                             data:         "https://www.w3.org/2022/wot/td/v1.1",
-                                            data:         "https://www.w3.org/2022/wot/discovery/tdd"
+                                            data:         "https://www.w3.org/2022/wot/discovery"
                                             data:     ],
                                             data:     "description": "This is a new TD",
                                             data:     "id": "urn:example:simple-td",

--- a/index.html
+++ b/index.html
@@ -827,9 +827,6 @@ img.wot-diagram {
 
                 <section id="exploration-td-type-thingdirectory" class="normative">
                     <h4>`ThingDirectory`</h4>
-                    <div class="issue" data-number="148">
-                        The type URIs used below are tentative and subject to change.
-                    </div>  
 
                     <span class="rfc2119-assertion" id="exploration-directory-description-type"> 
                         A TD which describes a Thing Description Directory instance MUST use type `ThingDirectory` from the
@@ -840,10 +837,7 @@ img.wot-diagram {
                 
                 </section>
                 <section id="exploration-td-type-thinglink" class="normative">
-                    <h4>`ThingLink`</h4>
-                    <div class="issue" data-number="148">
-                        The type URIs used below are tentative and subject to change.
-                    </div>  
+                    <h4>`ThingLink`</h4>  
 
                     <span class="rfc2119-assertion" id="exploration-link-description-type"> 
                         A TD which describes a reference to another TD MUST use type `ThingLink` from the
@@ -880,10 +874,7 @@ img.wot-diagram {
                                 },
                                 "title": "Example TD referencing another"
                             }
-                        </pre>
-                        <div class="issue" data-number="148">
-                            The context URIs are tentative and subject to change.
-                        </div>                    
+                        </pre>                   
                     </aside>
                     <p>
                         A Thing Link can be used in various scenarios. For example:
@@ -1699,10 +1690,7 @@ img.wot-diagram {
                                         },
                                         "title": "Simple TD"
                                     }
-                                </pre>
-                                <div class="issue" data-number="148">
-                                    The context URIs are tentative and subject to change.
-                                </div>                    
+                                </pre>                   
                             </aside>
                             <p>
                             This is an <a>Enriched TD</a> which includes the registration information
@@ -1733,10 +1721,7 @@ img.wot-diagram {
                                         },
                                         "title": "Anonymous TD"
                                     }
-                                </pre>
-                                <div class="issue" data-number="148">
-                                    The context URIs are tentative and subject to change.
-                                </div>                    
+                                </pre>                   
                             </aside>
 
                         <p>
@@ -1768,10 +1753,7 @@ img.wot-diagram {
                                         },
                                         "title": "Expirable TD"
                                     }
-                                </pre>
-                                <div class="issue" data-number="148">
-                                    The context URIs are tentative and subject to change.
-                                </div>                    
+                                </pre>                   
                             </aside>
                             <p>
                             For the sake of readability, the time values in this example are set to exact numbers.
@@ -2308,9 +2290,6 @@ img.wot-diagram {
                                             data: }
                                             id: event_1
                                         </pre>
-                                        <div class="issue" data-number="148">
-                                            The context URIs are tentative and subject to change.
-                                        </div>
                                     </aside>
                                 </li>
                                 <li>


### PR DESCRIPTION
Resolves points 1b, 2, 3 of [#463.](https://github.com/w3c/wot-discovery/issues/463#issuecomment-1485272509), copied here for reference:
1. To be consistent with the TD spec, use "https://www.w3.org/2022/wot/discovery/did" for the DID @context reference.
    a. Update the Discovery doc
    b. Update the DID PR at https://github.com/w3c/did-spec-registries/pull/486)
2. Also update the URL for the TDD vocabulary to "https://www.w3.org/2022/wot/discovery/tdd" (this changes both the year, to be consistent with the TD spec, and adds "tdd" so that both ontology files are at the same level).
3. Update all examples, etc. to use the correct URLs.

The PR against the DID registry has also been updated to use 2022.

Other changes:
- Got rid of github.io urls generally, in preparation for PR transition, replacing all non-DID contexts with the https://www.w3.org/2022/wot/discovery/tdd.  Note that this context URL is also used for collections and event reports.  We *could* use different context files for these but I did not want to deviate too far from the original intent, given that CR/PR is supposed to just be editorial changes.
- Updated the TD @context references to the one defined in the TD1.1 specification.
- Made sure to use https URLs generally and consistently for context files.

Note that some additional steps are needed to fully resolve #463 - in particular we need to update implementations to use the new URLs, need to revalidate tests, and need to make the relevant ontologies available at the given URLs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/471.html" title="Last updated on May 22, 2023, 3:25 PM UTC (77e8f96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/471/209c083...mmccool:77e8f96.html" title="Last updated on May 22, 2023, 3:25 PM UTC (77e8f96)">Diff</a>