### PR TITLE
Resolve tdd-registrationinfo-expiry-config

### DIFF
--- a/index.html
+++ b/index.html
@@ -1369,9 +1369,10 @@ img.wot-diagram {
                             their expiry times.</span>
                         Prescribing a global mandate or upper limit for the expiry time is
                         application-specific and beyond the scope of this specification.
-                        <span class="rfc2119-assertion" id="tdd-registrationinfo-expiry-config">
-                            The servers MAY mandate or set a configurable upper limit to expiry times
-                            and refuse incompliant requests.</span>
+                        <!-- <span class="rfc2119-assertion" id="tdd-registrationinfo-expiry-config"> -->
+                            Servers may mandate or set a configurable upper limit to expiry times
+                            and refuse incompliant requests.
+                        <!-- </span> -->
                         
                         The purging by servers is particularly beneficial when interacting with
                         clients (e.g. IoT devices) that are unable to explicitly deregister


### PR DESCRIPTION
- Resolve at-risk assertion tdd-registrationinfo-expiry-config
- Keep statement, but downgrade (MAY -> may) to an informative statement, comment out markup.
- Minor wording correction ("The servers" -> "Servers"): same meaning, less awkward English.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/482.html" title="Last updated on May 19, 2023, 3:34 PM UTC (1de93ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/482/25bf37a...mmccool:1de93ec.html" title="Last updated on May 19, 2023, 3:34 PM UTC (1de93ec)">Diff</a>