### PR TITLE
Resolve tdd-http-alternate-language and tdd-validation-response-lang

### DIFF
--- a/index.html
+++ b/index.html
@@ -1515,13 +1515,18 @@ img.wot-diagram {
                     </ul>
 
                 <p>
-                    <span class="rfc2119-assertion" id="tdd-http-alternate-language">
-                        A Directory server MAY provide modified TDs or error responses using a different
-                        default language after server-driven content negotiation, 
-                        that is by honouring the request's Accept-Language header.</span>
                     The process of modifying the default language of a TD using translations already
-                    provided in a TD is described in the WoT Thing Description 1.1 specification
+                    provided in a TD is normatively described in the WoT Thing Description 1.1 specification
                     [[wot-thing-description11]].
+                    <!-- <span class="rfc2119-assertion" id="tdd-http-alternate-language"> -->
+                    <!-- This assertion was removed but technically the process of transforming TDs to
+                         use a different default language is covered, normatively, by the TD 1.1 spec,
+                         and by the interpretation of a TDD as a TD Processor. -->
+                        Using this process,
+                        a Directory server may provide modified TDs, or its own TD, using a different
+                        default language after server-driven content negotiation, 
+                        that is by honouring the request's Accept-Language header.
+                    <!-- </span> -->
 
                 <section id="exploration-directory-api-things" class="normative">
                     <h4>Things API</h4>
@@ -2154,10 +2159,14 @@ img.wot-diagram {
                             This is necessary to represent the error in a machine-readable way. 
                             <span class="rfc2119-assertion" id="tdd-validation-response-utf-8">
                                 All validation error responses described using Problem Details MUST be encoded using UTF-8.</span>
-                            <span class="rfc2119-assertion" id="tdd-validation-response-lang">
-                                Validation error responses MAY report details in different languages using
+                            <!-- <span class="rfc2119-assertion" id="tdd-validation-response-lang"> -->
+                            <!-- Technically we don't need this assertion, covered by more general assertions
+                                 about supporting language negotiation for error messages -->
+                            As already stated in general for error reporting,
+                                validation error responses may report details in different languages using
                                 proactive negotiation, if the <code>Accept-Language</code> header field has been
-                                set in the HTTP request [[RFC7231]].</span>
+                                set in the HTTP request [[RFC7231]].
+                            <!-- </span> -->
                         </p>
                         <p>
                         [[[#example-validation-error]]] is an example error response with two validation errors.


### PR DESCRIPTION
- Resolve at-risk assertions ttdd-http-alternate-language and tdd-validation-response-lang
- Keep statements, but both downgraded (MAY -> may) to informative statements, commenting out markup.
- The tdd-http-alternative-language statement can be read as being implied by normative content in the TD 1.1 specification.
     - Some informative text around the assertion was modified and statements were reordered to make this clearer.
     - See also the related exploration-server-http-alternate-language assertion (not at risk)
- The tdd-validation-response-lang statement was for a particular error, but there is already an general assertion, tdd-http-error-response-lang, that applies to ALL HTTP API errors, and it is not at risk.  So technically this statement (applying only to validation) is redundant.  So while the statement is now informative, added a prefix: "As already stated in general for error reporting, " to make this clear.