### PR TITLE
Resolve resolve-tdd-notification-data-diff-unsupported

### DIFF
--- a/index.html
+++ b/index.html
@@ -2358,8 +2358,8 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <!-- <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported"> -->
-                                    If a server does not support the `diff` query parameter 
-                                    it is recommended that implementations reject such requests with an error.
+                                        When a server which does not support the `diff` query parameter 
+                                        is requested with such query parameter, it should reject the request.
                                     <!-- span -->
                                     This is to inform clients about the lack of such functionality at 
                                     connection time and avoid runtime exceptions caused by missing

--- a/index.html
+++ b/index.html
@@ -2357,13 +2357,12 @@ img.wot-diagram {
                                     the payload of `thing_deleted` events when `diff` is set to `true`. 
                                 </li>
                                 <li>
-                                    <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported">
-                                        When a server which does not support the `diff` query parameter 
-                                        is requested with such query parameter, it MUST
-                                        reject the request.
-                                    </span>
-                                    This is to inform the clients about the lack of such functionality at the
-                                    connection time to avoid runtime exceptions caused by missing
+                                    <!-- <span class="rfc2119-assertion" id="tdd-notification-data-diff-unsupported"> -->
+                                    If a server does not support the `diff` query parameter 
+                                    it is recommended that implementations reject such requests with an error.
+                                    <!-- span -->
+                                    This is to inform clients about the lack of such functionality at 
+                                    connection time and avoid runtime exceptions caused by missing
                                     event data attributes.
                                 </li>
                             </ul>


### PR DESCRIPTION
- Resolve at-risk assertion tdd-notification-data-diff-unsupported
- Keep statement, but downgrade to an informative statement, reword (say "recommended" rather than "MUST") comment out markup.
- This one is tricky because it really *should* be an assertion, as not doing this will lead to an interoperability problem.  The annoying this is that it only applies to contributors who implemented event notifications but NOT this feature, and everyone who implemented events DID implement this feature.  
- IMO the best we can do is point out that not reporting an error if you don't implement this feature will cause a problem.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/484.html" title="Last updated on May 22, 2023, 2:17 PM UTC (635ea65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/484/25bf37a...mmccool:635ea65.html" title="Last updated on May 22, 2023, 2:17 PM UTC (635ea65)">Diff</a>