### PR TITLE
Resolve sort_by specification issue

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -47,25 +47,11 @@
                         "collection"
                     ],
                     "default": "array"
-                },
-                "sort_by": {
-                    "title": "Comparator TD attribute for collection sorting",
-                    "type": "string",
-                    "default": "id"
-                },
-                "sort_order": {
-                    "title": "Sorting order",
-                    "type": "string",
-                    "enum": [
-                        "asc",
-                        "desc"
-                    ],
-                    "default": "asc"
                 }
             },
             "forms": [
                 {
-                    "href": "/things{?offset,limit,format,sort_by,sort_order}",
+                    "href": "/things{?offset,limit,format}",
                     "htv:methodName": "GET",
                     "response": {
                         "description": "Success response",

--- a/index.html
+++ b/index.html
@@ -2000,7 +2000,11 @@ img.wot-diagram {
                                         by the unique identifier of TDs.</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order">
                                         The server MAY support sorting by other TD attributes using
-                                        query arguments: `sort_by` to select a field (e.g. `created`)
+                                        query arguments: `sort_by` to select a field using 
+                                        either 
+                                          a top-level field name (e.g. `title`) 
+                                        or 
+                                          a JSON Pointer [[RFC6901] (e.g. `/title`)
                                         and `sort_order` to choose the order
                                         (i.e. `asc` or `desc` for ascending and descending ordering).</span>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">

--- a/index.html
+++ b/index.html
@@ -1501,7 +1501,7 @@ img.wot-diagram {
                     <ul>
                         <li>
                             If the missing feature is to customize functionality of an
-                            existing API (e.g. custom sort ordering when listing),
+                            existing API
                             use 400 (Bad Request) or 501 (Not Implemented).
                         </li>
                         <li>
@@ -1998,17 +1998,17 @@ img.wot-diagram {
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-default">
                                         The collection MUST be sorted in ascending order using Unicode code point order
                                         by the unique identifier of TDs.</span>
-                                 <!-- Made informative since underspecified in the original, e.g. how a field should be selected was
-                                       not clearly stated.  This revision says JSON pointer to be clear, but that version only had one
-                                       implementation (that I know of).  However, taking out the selection of custom fields makes all the
-                                       other assertions here not-so-useful.  Sort order might be useful even on id but it's mixed in
-                                       with another assertion, so we don't have separate test data for it.
+                            <!-- Made informative since underspecified in the original, e.g. how a field should be selected was
+                                 not clearly stated.  This revision says JSON pointer to be clear, but that version only had one
+                                 implementation (that I know of).  However, taking out the selection of custom fields makes all the
+                                 other assertions here not-so-useful.  Sort order might be useful even on id but it's mixed in
+                                 with another assertion, so we don't have separate test data for it.
 
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order">
                                         The server MAY support sorting by other TD attributes using
                                         query arguments: `sort_by` to select a field 
-                                          <!-- older example, assumes plain field syntax, top-level fields only? --> (e.g. `created`)
-                                          <!-- proposed --> using a JSON Pointer [[RFC6901] (e.g. `/title`) <!-- to be discussed; + "plain field" syntax? -->
+                                          [!-- older example, assumes plain field syntax, top-level fields only? --] (e.g. `created`)
+                                          [!-- proposed --] using a JSON Pointer [[RFC6901] (e.g. `/title`) [!-- to be discussed; + "plain field" syntax? --]
                                         and `sort_order` to choose the order
                                         (i.e. `asc` or `desc` for ascending and descending ordering).</span> 
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">

--- a/index.html
+++ b/index.html
@@ -1996,17 +1996,21 @@ img.wot-diagram {
                                 </li>
                                 <li>
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-default">
-                                        By default, the collection MUST be sorted using Unicode code point order
+                                        The collection MUST be sorted in ascending order using Unicode code point order
                                         by the unique identifier of TDs.</span>
+                                 <!-- Made informative since underspecified in the original, e.g. how a field should be selected was
+                                       not clearly stated.  This revision says JSON pointer to be clear, but that version only had one
+                                       implementation (that I know of).  However, taking out the selection of custom fields makes all the
+                                       other assertions here not-so-useful.  Sort order might be useful even on id but it's mixed in
+                                       with another assertion, so we don't have separate test data for it.
+
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order">
                                         The server MAY support sorting by other TD attributes using
-                                        query arguments: `sort_by` to select a field using 
-                                        either 
-                                          a top-level field name (e.g. `title`) 
-                                        or 
-                                          a JSON Pointer [[RFC6901] (e.g. `/title`)
+                                        query arguments: `sort_by` to select a field 
+                                          <!-- older example, assumes plain field syntax, top-level fields only? --> (e.g. `created`)
+                                          <!-- proposed --> using a JSON Pointer [[RFC6901] (e.g. `/title`) <!-- to be discussed; + "plain field" syntax? -->
                                         and `sort_order` to choose the order
-                                        (i.e. `asc` or `desc` for ascending and descending ordering).</span>
+                                        (i.e. `asc` or `desc` for ascending and descending ordering).</span> 
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-orderable">
                                         A server MUST reject requests to sort on fields that do not have 
                                         values that are orderable basic types.</span>
@@ -2018,6 +2022,7 @@ img.wot-diagram {
                                     <span class="rfc2119-assertion" id="tdd-things-list-pagination-order-utf-8">
                                         Sorting order MUST always be defined based on Unicode code points on
                                         the relevant fields.</span>
+			    -->
                                 </li>
                             </ul>
                             <p>


### PR DESCRIPTION
Resolves #480 
- Proposes change that allows field to sort_by to be specified by *either* a top-level field name *or* a JSON pointer (with RFC citation)
- an implementation could support both, since JSON pointers will always have a leading slash in this context, so if there is no slash, it can be interpreted as a field name... unless a field name starts with a slash.  Don't do that.
- Should cover all existing implementations so testing data should still be valid
- We should clean this up in the next version of the Discovery spec.  In particular we should specify that *both* should be supported by all implementations to avoid interoperability issues, or just allow one (like JSON Pointers), but that would go too far at this point (non-editorial, impacting implementations, etc).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/488.html" title="Last updated on May 22, 2023, 3:07 PM UTC (4b40142)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/488/25bf37a...mmccool:4b40142.html" title="Last updated on May 22, 2023, 3:07 PM UTC (4b40142)">Diff</a>