### PR TITLE
Resolve exploration-server-http-alternate-language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1135,11 +1135,14 @@ img.wot-diagram {
                             server-driven content negotiation, that is by honoring the 
                             request's Accept and Accept-Encoding headers and responding with the supported
                             TD serialization and equivalent Content-Type and Content-Encoding headers.</span>
-                        <span class="rfc2119-assertion" id="exploration-server-http-alternate-language">
-                            An HTTP-based TD Server providing a <a>TD</a> 
-                            MAY provide modified TDs or error responses 
+                        <!-- <span class="rfc2119-assertion" id="exploration-server-http-alternate-language"> -->
+                        <!-- See also tdd-http-alternate-language -->
+                            In addition, following the process normatively defined in the WoT Thing Description 1.1 specification
+                            [[wot-thing-description11]],
+                            an HTTP-based TD Server providing a <a>TD</a> 
+                            may provide modified TDs or error responses 
                             using a different default language after server-driven content negotiation, 
-                            that is by honouring the request's Accept-Language header.</span>
+                            that is by honouring the request's Accept-Language header.<!-- </span> -->
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="exploration-server-http-head">
@@ -1539,8 +1542,7 @@ img.wot-diagram {
                     <!-- This assertion was removed but technically the process of transforming TDs to
                          use a different default language is covered, normatively, by the TD 1.1 spec,
                          and by the interpretation of a TDD as a TD Processor. 
-                         See also the related exploration-server-http-alternate-language for TD Servers - 
-                         but each endpoint in a TDD providing a single TD can be considered a TD Server, so... -->
+                         See also the related exploration-server-http-alternate-language for TD Servers. -->
                         Using this process,
                         a Directory server may provide modified TDs, or its own TD, using a different
                         default language after server-driven content negotiation, 

--- a/index.html
+++ b/index.html
@@ -1142,7 +1142,7 @@ img.wot-diagram {
                             an HTTP-based TD Server providing a <a>TD</a> 
                             may provide modified TDs or error responses 
                             using a different default language after server-driven content negotiation, 
-                            that is by honouring the request's Accept-Language header.<!-- </span> -->
+                            that is by honoring the request's Accept-Language header.<!-- </span> -->
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="exploration-server-http-head">

--- a/static.html
+++ b/static.html
@@ -1347,11 +1347,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                             server-driven content negotiation, that is by honoring the 
                             request's Accept and Accept-Encoding headers and responding with the supported
                             TD serialization and equivalent Content-Type and Content-Encoding headers.</span>
-                        <span class="rfc2119-assertion" id="exploration-server-http-alternate-language">
-                            An HTTP-based TD Server providing a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-14">TD</a> 
-                            <em class="rfc2119">MAY</em> provide modified TDs or error responses 
+                        
+                        
+                            In addition, following the process normatively defined in the WoT Thing Description 1.1 specification
+                            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>],
+                            an HTTP-based TD Server providing a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-14">TD</a> 
+                            may provide modified TDs or error responses 
                             using a different default language after server-driven content negotiation, 
-                            that is by honouring the request's Accept-Language header.</span>
+                            that is by honouring the request's Accept-Language header.
                     </p>
                     <p>
                         <span class="rfc2119-assertion" id="exploration-server-http-head">
@@ -2682,7 +2685,7 @@ id: event_3</code></pre>
                         In this case, <code>application/x-empty</code> can be used to
                         ensure that the TD generated from the TM below is valid.
                     </p>
-                    <pre class="advisement json respec-offending-element" data-include="directory.tm.json" data-include-id="include-3605688233412083" title="`data-include` failed: `directory.tm.json` (Failed to fetch)." id="respec-offender-data-include-failed-directory-tm-json-failed-to-fetch"></pre>
+                    <pre class="advisement json respec-offending-element" data-include="directory.tm.json" data-include-id="include-542525811962522" title="`data-include` failed: `directory.tm.json` (Failed to fetch)." id="respec-offender-data-include-failed-directory-tm-json-failed-to-fetch"></pre>
 
 
                     <div class="note" id="issue-container-generatedID-2"><div role="heading" class="ednote-title marker" id="h-ednote-2" aria-level="6"><span>Editor's note</span><span class="issue-label">: Context URIs</span></div><p class="">
@@ -3272,7 +3275,7 @@ a change in ownership).
         The following JSON Schema specifies the extensions used in <a href="#dfn-wot-enriched-thing-description" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-enriched-thing-description-7">Enriched TDs</a>.
         It can be used for validating <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-47">TDs</a> by a <a href="#dfn-wot-tdd" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-tdd-1">TDD</a>
         as prescribed in <a href="#exploration-directory-api-things-validation" data-matched-text="[[[#exploration-directory-api-things-validation]]]" class="sec-ref"><bdi class="secno">7.3.2.1.6 </bdi>Validation</a>.
-        <pre class="advisement json respec-offending-element" data-include="validation/td-discovery-extensions-json-schema.json" data-include-id="include-27325185311589073" title="`data-include` failed: `validation/td-discovery-extensions-json-schema.json` (Failed to fetch)." id="respec-offender-data-include-failed-validation-td-discovery-extensions-json-schema-json-failed-to-fetch"></pre>
+        <pre class="advisement json respec-offending-element" data-include="validation/td-discovery-extensions-json-schema.json" data-include-id="include-909214941139038" title="`data-include` failed: `validation/td-discovery-extensions-json-schema.json` (Failed to fetch)." id="respec-offender-data-include-failed-validation-td-discovery-extensions-json-schema-json-failed-to-fetch"></pre>
     </section>
     
     <section id="changes" class="appendix"><div class="header-wrapper"><h2 id="b-recent-specification-changes"><bdi class="secno">B. </bdi>Recent Specification Changes</h2><a class="self-link" href="#changes" aria-label="Permalink for Appendix B."></a></div>


### PR DESCRIPTION
See PR #492 - exploration-server-http-alternate-language did not actually get enough implementations to resolve its at-risk status.  This PR demotes it to an informative statement but adds a similar reference to the TD 1.1 spec defining the process by which the default language for TDDs can be changed as the related (demoted) assertion for TDDs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-discovery/pull/493.html" title="Last updated on May 24, 2023, 12:33 PM UTC (4996db3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/493/0bf3c7b...mmccool:4996db3.html" title="Last updated on May 24, 2023, 12:33 PM UTC (4996db3)">Diff</a>