### PR TITLE
Render changelog in discovery ontology from RDF

### DIFF
--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -7,8 +7,12 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "REC",
+            specStatus : "ED",
+            copyrightStart : 2017,
             latestVersion: null,
+            group: "wg/wot",
+            wgPublicList : "public-wot-wg",
+            edDraftURI: "https://w3c.github.io/wot-discovery/context/discovery-ontology",
             editors: [{
                 name: "Andrea Cimmino"
             }, {

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -73,7 +73,7 @@
             <dl>
                 <!-- Changelog rendered from .ttl files -->
                 <dd>1.0.1-a1</dd><dt>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dt>
-                <dd>0.1.2</dd><dt>Initial version</dt>
+                <dd>0.1.2</dd><dt>Initial release. Placeholder HTML only.</dt>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -59,14 +59,16 @@
     <section id="changelog">
         <h2>Change Log</h2>
             <p>
-            The following lists the changes to the ontology for each version.  Semantic versioning is used, so major version changes are breaking,
-minor version changes are substantial but non-breaking, and bug fix versions are small and non-breaking.
+                The following lists the changes to the ontology for each
+                version.
+                Semantic versioning is used, so major version changes are
+                breaking, minor version changes are substantial but
+                non-breaking, and bug fix versions are small and non-breaking.
             </p>
             <dl>
-            <dt>Version 1.0.1</dt><dd>Script used to render HTML from TTL.  TTL updated to include annotations and comments, and defining default namespace.
-            </dd>
-            <dt>Version 1.0.0</dt><dd>Initial release.  Placeholder HTML only.
-            </dd>
+                <!-- Changelog rendered from .ttl file -->
+                <dt>"1.0.1"</dt><dd>"Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace."</dd>
+<dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -67,8 +67,10 @@
             </p>
             <dl>
                 <!-- Changelog rendered from .ttl file -->
-                <dt>"1.0.1"</dt><dd>"Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace."</dd>
-<dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
+                <dt>1.0.1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dd>
+                <!-- Hardcoded change log values-->
+                <!-- TODO: Should these be replaced? -->
+                <dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -72,8 +72,8 @@
             </p>
             <dl>
                 <!-- Changelog rendered from .ttl files -->
-                <dd>1.0.1-a1</dd><dt>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dt>
-                <dd>0.1.2</dd><dt>Initial release. Placeholder HTML only.</dt>
+                <dt>1.0.1-a1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dd>
+                <dt>0.1.2</dt><dd>Initial release. Placeholder HTML only.</dd>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -60,6 +60,7 @@
 <section id="expires"><h4>expires</h4><p>IRI: <code>https://github.com/w3c/wot-discovery#expires</code></p><span>Provides the absolute time when the TD instance registration expires.</span><table class="def numbered"><tbody></tbody></table></section>
 <section id="retrieved"><h4>retrieved</h4><p>IRI: <code>https://github.com/w3c/wot-discovery#retrieved</code></p><span>The absolute time at which the TD was retrieved from the server.</span><table class="def numbered"><tbody></tbody></table></section>
 <section id="ttl"><h4>ttl</h4><p>IRI: <code>https://github.com/w3c/wot-discovery#ttl</code></p><span>Time-to-live: relative amount of time in seconds from the registration time until when the TD instance registration expires.</span><table class="def numbered"><tbody></tbody></table></section></section><section><h3>Annotation Properties</h3><p>No AnnotationProperty found in the ontology.</p></section></section>
+
     <section id="changelog">
         <h2>Change Log</h2>
             <p>
@@ -70,11 +71,9 @@
                 non-breaking, and bug fix versions are small and non-breaking.
             </p>
             <dl>
-                <!-- Changelog rendered from .ttl file -->
-                <dt>1.0.1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dd>
-                <!-- Hardcoded change log values-->
-                <!-- TODO: Should these be replaced? -->
-                <dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
+                <!-- Changelog rendered from .ttl files -->
+                <dt>1.0.1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dt>
+                <dt>1.0.0</dt><dd>Initial release. Placeholder HTML only.</dt>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -72,8 +72,8 @@
             </p>
             <dl>
                 <!-- Changelog rendered from .ttl files -->
-                <dt>1.0.1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dt>
-                <dt>1.0.0</dt><dd>Initial release. Placeholder HTML only.</dt>
+                <dd>1.0.1-a1</dd><dt>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dt>
+                <dd>0.1.2</dd><dt>Initial version</dt>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -72,7 +72,7 @@
             </p>
             <dl>
                 <!-- Changelog rendered from .ttl files -->
-                <dt>1.0.1-a1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dd>
+                <dt>0.2.0-a1</dt><dd>Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace.</dd>
                 <dt>0.1.2</dt><dd>Initial release. Placeholder HTML only.</dd>
             </dl>
      </section>

--- a/context/discovery-ontology.template.html
+++ b/context/discovery-ontology.template.html
@@ -44,17 +44,19 @@
 
     <!-- axioms rendered from RDF definitions -->
     %s
+
     <section id="changelog">
         <h2>Change Log</h2>
             <p>
-            The following lists the changes to the ontology for each version.  Semantic versioning is used, so major version changes are breaking,
-minor version changes are substantial but non-breaking, and bug fix versions are small and non-breaking.
+                The following lists the changes to the ontology for each
+                version.
+                Semantic versioning is used, so major version changes are
+                breaking, minor version changes are substantial but
+                non-breaking, and bug fix versions are small and non-breaking.
             </p>
             <dl>
-            <dt>Version 1.0.1</dt><dd>Script used to render HTML from TTL.  TTL updated to include annotations and comments, and defining default namespace.
-            </dd>
-            <dt>Version 1.0.0</dt><dd>Initial release.  Placeholder HTML only.
-            </dd>
+                <!-- Changelog rendered from .ttl file -->
+                %s
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.template.html
+++ b/context/discovery-ontology.template.html
@@ -7,8 +7,12 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "REC",
+            specStatus : "ED",
+            copyrightStart : 2017,
             latestVersion: null,
+            group: "wg/wot",
+            wgPublicList : "public-wot-wg",
+            edDraftURI: "https://w3c.github.io/wot-discovery/context/discovery-ontology",
             editors: [{
                 name: "Andrea Cimmino"
             }, {

--- a/context/discovery-ontology.template.html
+++ b/context/discovery-ontology.template.html
@@ -57,6 +57,9 @@
             <dl>
                 <!-- Changelog rendered from .ttl file -->
                 %s
+                <!-- Hardcoded change log values-->
+                <!-- TODO: Should these be replaced? -->
+                <dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.template.html
+++ b/context/discovery-ontology.template.html
@@ -55,11 +55,8 @@
                 non-breaking, and bug fix versions are small and non-breaking.
             </p>
             <dl>
-                <!-- Changelog rendered from .ttl file -->
+                <!-- Changelog rendered from .ttl files -->
                 %s
-                <!-- Hardcoded change log values-->
-                <!-- TODO: Should these be replaced? -->
-                <dt>"1.0.0"</dt><dd>"Initial release. Placeholder HTML only"</dd>
             </dl>
      </section>
 </body>

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -1,4 +1,5 @@
 @prefix : <https://github.com/w3c/wot-discovery#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -14,7 +15,8 @@
 : rdf:type owl:Ontology ;
 	dc:creator "Andrea Cimmino" ;
 	dc:creator "Farshid Tavakolizadeh" ;
-	owl:versionInfo "0.1.2" ;
+	owl:versionInfo "1.0.0" ;
+	adms:versionNotes "Foobar";
 	vann:preferredNamespacePrefix "discovery" ;
 	vann:preferredNamespaceUri "https://github.com/w3c/wot-discovery#" ;
 	dc:title "WoT discovery ontology" ;
@@ -141,3 +143,17 @@
 #################################################################
 # General Axioms
 #################################################################
+
+#################################################################
+# Changelog
+#################################################################
+
+:version101 a :changeLogEntry ;
+  rdfs:label "Version 1.0.1" ;
+  owl:versionInfo "1.0.1" ;
+  adms:versionNotes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." .
+
+:version100 a :changeLogEntry ;
+  rdfs:label "Version 1.0.0" ;
+  owl:versionInfo "1.0.0" ;
+  adms:versionNotes "Initial release. Placeholder HTML only"; .

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -1,5 +1,4 @@
 @prefix : <https://github.com/w3c/wot-discovery#> .
-@prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -15,8 +14,10 @@
 : rdf:type owl:Ontology ;
 	dc:creator "Andrea Cimmino" ;
 	dc:creator "Farshid Tavakolizadeh" ;
-	owl:versionInfo "1.0.0" ;
-	adms:versionNotes "Foobar";
+	owl:versionInfo "1.0.1" ;
+	# TODO: Add proper owl:priorVersion
+	owl:priorVersion "https://example.org/todo";
+    vann:changes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." ;
 	vann:preferredNamespacePrefix "discovery" ;
 	vann:preferredNamespaceUri "https://github.com/w3c/wot-discovery#" ;
 	dc:title "WoT discovery ontology" ;
@@ -143,17 +144,3 @@
 #################################################################
 # General Axioms
 #################################################################
-
-#################################################################
-# Changelog
-#################################################################
-
-:version101 a :changeLogEntry ;
-  rdfs:label "Version 1.0.1" ;
-  owl:versionInfo "1.0.1" ;
-  adms:versionNotes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." .
-
-:version100 a :changeLogEntry ;
-  rdfs:label "Version 1.0.0" ;
-  owl:versionInfo "1.0.0" ;
-  adms:versionNotes "Initial release. Placeholder HTML only"; .

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -17,7 +17,7 @@
 	owl:versionInfo "1.0.1" ;
 	# TODO: Add proper owl:priorVersion
 	owl:priorVersion "https://example.org/todo";
-    vann:changes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." ;
+	vann:changes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." ;
 	vann:preferredNamespacePrefix "discovery" ;
 	vann:preferredNamespaceUri "https://github.com/w3c/wot-discovery#" ;
 	dc:title "WoT discovery ontology" ;

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -14,9 +14,9 @@
 : rdf:type owl:Ontology ;
 	dc:creator "Andrea Cimmino" ;
 	dc:creator "Farshid Tavakolizadeh" ;
-	owl:versionInfo "1.0.1" ;
+	owl:versionInfo "1.0.1-a1" ;
 	# TODO: Add proper owl:priorVersion
-	owl:priorVersion "https://example.org/todo";
+	owl:priorVersion "https://raw.githubusercontent.com/w3c/wot-discovery/main/publication/6-resources/ontology/discovery-ontology.ttl";
 	vann:changes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." ;
 	vann:preferredNamespacePrefix "discovery" ;
 	vann:preferredNamespaceUri "https://github.com/w3c/wot-discovery#" ;

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -14,7 +14,7 @@
 : rdf:type owl:Ontology ;
 	dc:creator "Andrea Cimmino" ;
 	dc:creator "Farshid Tavakolizadeh" ;
-	owl:versionInfo "1.0.1-a1" ;
+	owl:versionInfo "0.2.0-a1" ;
 	# TODO: Add proper owl:priorVersion
 	owl:priorVersion "https://raw.githubusercontent.com/w3c/wot-discovery/main/publication/6-resources/ontology/discovery-ontology.ttl";
 	vann:changes "Script used to render HTML from TTL. TTL updated to include annotations and comments, and defining default namespace." ;

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -4,13 +4,105 @@
 
 import { readFileSync, writeFileSync } from "fs";
 import sttl from "sttl";
-import { load, query } from "urdf";
+import { load, query, loadFrom, clear } from "urdf";
 
-const ontology = readFileSync("context/discovery-ontology.ttl", "utf-8");
+async function obtainDataViaTemplate(template) {
+  sttl.register(template);
+  const data = await sttl.applyTemplates();
+  return data;
+}
+
+async function obtainPriorVersionUrl() {
+  return obtainDataViaTemplate(
+    `
+    template {
+      str(?priorVersion)
+    } where {
+      ?in a <http://www.w3.org/2002/07/owl#Ontology> ;
+          <http://www.w3.org/2002/07/owl#priorVersion> ?priorVersion
+    }
+    `
+  );
+}
+
+async function obtainChangeLogEntry() {
+  return obtainDataViaTemplate(
+    `
+    template {
+      "<dt>"
+        str(?versionInfo)
+      "</dt>"
+      "<dd>"
+        str(?changes)
+      "</dt>"
+    } where {
+      ?in a <http://www.w3.org/2002/07/owl#Ontology> ;
+          <http://www.w3.org/2002/07/owl#versionInfo> ?versionInfo ;
+          <http://purl.org/vocab/vann/changes> ?changes .
+    }
+    `
+  );
+}
+
+async function loadPriorVersion(priorVersion) {
+  // TODO: Remove file links
+  if (priorVersion.startsWith("file://")) {
+    const priorVersionPath = priorVersion.substring("file://".length);
+    const ontology = readFileSync(priorVersionPath, "utf-8");
+    await load(ontology);
+  } else {
+    await loadFrom(priorVersion);
+  }
+}
+
+async function reset(parameters) {
+  if (parameters?.fullReset === true) {
+    await clear();
+  }
+
+  sttl.clear();
+}
+
+function readTtlFile(filePath) {
+  return readFileSync(filePath, "utf-8");
+}
+
+async function obtainChangeLog() {
+  const changeLog = [];
+
+  const changeLogEntry = await obtainChangeLogEntry();
+  changeLog.push(changeLogEntry);
+
+  await reset({ fullReset: true });
+
+  const currentOntology = readTtlFile("context/discovery-ontology.ttl");
+  await load(currentOntology);
+  let priorVersionUrl = await obtainPriorVersionUrl();
+
+  await reset();
+
+  while (priorVersionUrl != null && priorVersionUrl.length > 0) {
+    await loadPriorVersion(priorVersionUrl);
+
+    const nextChangeLogEntry = await obtainChangeLogEntry();
+    changeLog.push(nextChangeLogEntry);
+
+    await reset({ fullReset: true });
+
+    await loadPriorVersion(priorVersionUrl);
+
+    priorVersionUrl = await obtainPriorVersionUrl();
+    await reset();
+  }
+
+  return changeLog;
+}
+
+const ontology = readTtlFile("context/discovery-ontology.ttl");
 await load(ontology);
 
-const sparqlTemplate = readFileSync("context/template.sparql", "utf-8");
-await sttl.register(sparqlTemplate);
+const sparqlTemplate = readTtlFile("context/template.sparql");
+sttl.register(sparqlTemplate);
 
 sttl.connect(async (sparqlQuery) => {
   const bindings = await query(sparqlQuery);
@@ -21,10 +113,19 @@ sttl.connect(async (sparqlQuery) => {
   };
 });
 
-const renderedOntology = await sttl.callTemplate("https://github.com/w3c/wot-discovery/ontology#main",
+let renderedOntology = await sttl.callTemplate(
+  "https://github.com/w3c/wot-discovery/ontology#main",
   {
     value: "discovery",
     type: "literal",
-  });
+  }
+);
 
-writeFileSync("context/discovery-ontology.html", renderedOntology)
+const changeLog = await obtainChangeLog();
+
+renderedOntology = renderedOntology.replace(
+  "%",
+  changeLog.join("\n                ")
+);
+
+writeFileSync("context/discovery-ontology.html", renderedOntology);

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -89,8 +89,6 @@ async function obtainChangeLog() {
 
     await reset({ fullReset: true });
 
-    await loadPriorVersion(priorVersionUrl);
-
     priorVersionUrl = await obtainPriorVersionUrl();
     await reset();
   }

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -6,6 +6,8 @@ import { readFileSync, writeFileSync } from "fs";
 import sttl from "sttl";
 import { load, query, clear } from "urdf";
 
+const initialVersionString = "Initial release. Placeholder HTML only."
+
 async function obtainOntologyMetaData(termIri) {
   const template = `
     template {
@@ -35,7 +37,7 @@ async function obtainChanges(options) {
   );
 
   if (changes.length === 0 && options?.useDefault === true) {
-    return "Initial version";
+    return initialVersionString;
   }
 
   return changes;

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -50,7 +50,7 @@ async function obtainChangeLogEntry(options) {
   const changes = await obtainChanges(options);
   await reset({ fullReset: true });
 
-  return `<dd>${versionInfo}</dd><dt>${changes}</dt>`;
+  return `<dt>${versionInfo}</dt><dd>${changes}</dd>`;
 }
 
 async function loadPriorVersion(priorVersion) {

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -30,7 +30,9 @@ async function obtainVersionInfo() {
 }
 
 async function obtainChanges(options) {
-  const changes = await obtainOntologyMetaData("http://purl.org/vocab/vann/changes");
+  const changes = await obtainOntologyMetaData(
+    "http://purl.org/vocab/vann/changes"
+  );
 
   if (changes.length === 0 && options?.useDefault === true) {
     return "Initial version";
@@ -50,7 +52,7 @@ async function obtainChangeLogEntry(options) {
 }
 
 async function loadPriorVersion(priorVersion) {
-  const response = await fetch(priorVersion)
+  const response = await fetch(priorVersion);
   const ontology = await response.text();
   await load(ontology);
 }
@@ -82,7 +84,7 @@ async function obtainChangeLog() {
   while (priorVersionUrl != null && priorVersionUrl.length > 0) {
     await loadPriorVersion(priorVersionUrl);
 
-    const changeLogEntry = await obtainChangeLogEntry({useDefault: true});
+    const changeLogEntry = await obtainChangeLogEntry({ useDefault: true });
     changeLog.push(changeLogEntry);
 
     await loadPriorVersion(priorVersionUrl);

--- a/context/renderOntology.js
+++ b/context/renderOntology.js
@@ -89,6 +89,8 @@ async function obtainChangeLog() {
 
     await reset({ fullReset: true });
 
+    await loadPriorVersion(priorVersionUrl);
+
     priorVersionUrl = await obtainPriorVersionUrl();
     await reset();
   }
@@ -122,7 +124,7 @@ let renderedOntology = await sttl.callTemplate(
 const changeLog = await obtainChangeLog();
 
 renderedOntology = renderedOntology.replace(
-  "%",
+  "%s",
   changeLog.join("\n                ")
 );
 

--- a/context/template.sparql
+++ b/context/template.sparql
@@ -52,18 +52,15 @@ template :axioms(?prefix) {
 }
 
 template :changelog(?prefix) {
-    "<dt>"
-        ?vi
-    "</dt>"
-    "<dd>"
-        ?vn
-    "</dd>"
+    format { "<dt>%s</dt>" ?versionInfo }
+    format { "<dd>%s</dd>" ?changes }
 } where {
-
-    ?cl a ontology:changeLogEntry ;
-        adms:versionNotes ?vn ;
-        owl:versionInfo ?vi .
-} order by desc(?vi)
+    ?o a owl:Ontology ;
+         owl:versionInfo ?versionInfo ;
+         owl:priorVersion ?priorVersion ;
+         vann:changes ?changes .
+    # TODO: Call template with priorVersion URL
+}
 
 template :individuals-section(?ns ?prefix) {
     "<section>"

--- a/context/template.sparql
+++ b/context/template.sparql
@@ -17,7 +17,6 @@ template :main-discovery (?prefix) {
     format {
         <file://./context/discovery-ontology.template.html>
         st:call-template(:axioms, ?prefix)
-        st:call-template(:changelog, ?prefix)
     }
 } where {}
 
@@ -49,17 +48,6 @@ template :axioms(?prefix) {
     ?o a owl:Ontology ;
        vann:preferredNamespaceUri ?ns ;
        vann:preferredNamespacePrefix ?prefix .
-}
-
-template :changelog(?prefix) {
-    format { "<dt>%s</dt>" ?versionInfo }
-    format { "<dd>%s</dd>" ?changes }
-} where {
-    ?o a owl:Ontology ;
-         owl:versionInfo ?versionInfo ;
-         owl:priorVersion ?priorVersion ;
-         vann:changes ?changes .
-    # TODO: Call template with priorVersion URL
 }
 
 template :individuals-section(?ns ?prefix) {

--- a/context/template.sparql
+++ b/context/template.sparql
@@ -1,9 +1,11 @@
+prefix adms: <http://www.w3.org/ns/adms#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix schema: <http://schema.org/>
 prefix vann: <http://purl.org/vocab/vann/>
 prefix st: <http://ns.inria.fr/sparql-template/>
+prefix ontology: <https://github.com/w3c/wot-discovery#>
 prefix : <https://github.com/w3c/wot-discovery/ontology#>
 
 template :main(?prefix) {
@@ -15,6 +17,7 @@ template :main-discovery (?prefix) {
     format {
         <file://./context/discovery-ontology.template.html>
         st:call-template(:axioms, ?prefix)
+        st:call-template(:changelog, ?prefix)
     }
 } where {}
 
@@ -47,6 +50,20 @@ template :axioms(?prefix) {
        vann:preferredNamespaceUri ?ns ;
        vann:preferredNamespacePrefix ?prefix .
 }
+
+template :changelog(?prefix) {
+    "<dt>"
+        ?vi
+    "</dt>"
+    "<dd>"
+        ?vn
+    "</dd>"
+} where {
+
+    ?cl a ontology:changeLogEntry ;
+        adms:versionNotes ?vn ;
+        owl:versionInfo ?vi .
+} order by desc(?vi)
 
 template :individuals-section(?ns ?prefix) {
     "<section>"


### PR DESCRIPTION
As discussed in the last discovery call, this PR tries to add a changelog to the `.ttl` file and render it dynamically in the HTML document from the `template.sparql` file. I am not sure yet if this is the best or even a good approach, so feedback is greatly appreciated :) 