### PR TITLE
Introduce DataSchema for property 'things'

### DIFF
--- a/directory.tm.json
+++ b/directory.tm.json
@@ -40,6 +40,7 @@
                 },
                 {
                     "type": "object",
+                    "description": "Verbose payload with pagination information, see format Uri variable",
                     "properties": {
                         "@context": {
                             "const": "https://www.w3.org/2022/wot/discovery"

--- a/directory.tm.json
+++ b/directory.tm.json
@@ -29,6 +29,47 @@
     "properties": {
         "things": {
             "description": "Retrieve all Thing Descriptions",
+            "oneOf": [
+                {
+                    "description": "Plain list of Thing Descriptions",
+                    "type": "array",
+                    "items": {
+                        "description": "Thing Description",
+                        "type": "object"
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "@context": {
+                            "const": "https://www.w3.org/2022/wot/discovery"
+                        },
+                        "@type": {
+                            "const": "ThingCollection"
+                        },
+                        "@id": {
+                            "description": "URI of this collection",
+                            "type": "string"
+                        },
+                        "members": {
+                            "description": "Thing Descriptions",
+                            "type": "array",
+                            "items": {
+                                "description": "Thing Description",
+                                "type": "object"
+                            }
+                        },
+                        "total": {
+                            "description": "Total number of Thing Descriptions in this collection",
+                            "type": "number"
+                        },
+                        "next": {
+                            "description": "URI of the next page",
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
             "uriVariables": {
                 "offset": {
                     "title": "Number of TDs to skip before the page",


### PR DESCRIPTION
When implementing the `exploreDirectory` method in `node-wot` and `dart_wot` we noticed that the TDD Thing Model doesn't provide any schema for the property `things`. For implementations even a simple schema that provides a basic structure for the payload can help with the validation. In scripting API we have the `value` function that does the validation using the JSONSchema provided in the affordance, without it the user is required to manually figure out what the payload is about and how to parse it. 

I think we can introduce this "simple" schema even if it does not guarantee that the array items are indeed Thing Descriptions, this is something left to the implementation (it is reasonable to think that the implementation is able to validate TDs with other means or it can even have the TD schema cached somewhere). Let me know what to think! ( I should have opened an issue for this but I thought having the schema would help the discussion)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-discovery/pull/538.html" title="Last updated on Jan 19, 2024, 9:19 AM UTC (fcbf0e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/538/72356d6...relu91:fcbf0e9.html" title="Last updated on Jan 19, 2024, 9:19 AM UTC (fcbf0e9)">Diff</a>