### PR TITLE
Replace custom JSONPath reference with RFC 9353

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,17 +111,6 @@
                 , publisher: "IETF"
                 , date: "11 May 2020"
             },
-            "JSONPATH": {
-                title: "JSONPath: Query expressions for JSON"
-                , href: "https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base"
-                , authors: [
-                    "Stefan Gössner"
-                    , "Glyn Normington"
-                    , "Carsten Bormann"
-                ]
-                , publisher: "IETF"
-                , status: "DRAFT",
-            },
             "wot-usecases" : {
                   title: "Web of Things (WoT): Use Cases"
                 , href: "https://w3c.github.io/wot-usecases/"
@@ -2445,7 +2434,7 @@ img.wot-diagram {
                         To discuss further:
                         Federated queries to other TDDs, Spatial and network-limited queries, Links
                     </p>
-                    This specification describes three search APIs: syntactic search with JSONPath [[?JSONPATH]],
+                    This specification describes three search APIs: syntactic search with JSONPath [[?RFC9535]],
                     syntactic search with XPath [[xpath-31]], and semantic search with SPARQL [[sparql11-overview]].
                     <span class="rfc2119-assertion" id="tdd-search-sparql">
                         The Directory MAY implement semantic search with SPARQL.</span>
@@ -2471,7 +2460,7 @@ img.wot-diagram {
                         Support for JSONPath Search API is optional.
                         If implemented, the JSONPath API must allow searching TDs using an HTTP <code>GET</code> request
                         at `/search/jsonpath?query={query}` endpoint, where `query` is the JSONPath expression.
-                        The request must contain a valid JSONPath [[?JSONPATH]] as searching parameter.
+                        The request must contain a valid JSONPath [[?RFC9535]] as searching parameter.
                         A successful response must have 200 (OK) status, contain
                         <code>application/json</code> in the Content-Type header, and
                         a set of complete TDs or a set of TD fragments in the body.


### PR DESCRIPTION
As JSONPath has just been released as an [RFC](https://datatracker.ietf.org/doc/rfc9535/), this PR updates the (currently informative) reference to it accordingly. At the time of opening this PR, Specref has not yet been updated so the new reference is not correctly rendered yet; however, that should change in the next couple of days.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-discovery/pull/542.html" title="Last updated on Feb 22, 2024, 12:03 PM UTC (e525649)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-discovery/542/54dbf94...JKRhb:e525649.html" title="Last updated on Feb 22, 2024, 12:03 PM UTC (e525649)">Diff</a>