### PR TITLE
fix(ontology): extract current version from .ttl file

### DIFF
--- a/context/discovery-ontology.html
+++ b/context/discovery-ontology.html
@@ -38,7 +38,7 @@
     </section>
     <section id='sotd'>
         <p>
-            Version 1.0.1.
+            Version 0.2.0-a1.
             See [[[#changelog]]].
         </p>
     </section>

--- a/context/discovery-ontology.template.html
+++ b/context/discovery-ontology.template.html
@@ -38,7 +38,7 @@
     </section>
     <section id='sotd'>
         <p>
-            Version 1.0.1.
+            Version %s.
             See [[[#changelog]]].
         </p>
     </section>

--- a/context/template.sparql
+++ b/context/template.sparql
@@ -16,9 +16,17 @@ template :main(?prefix) {
 template :main-discovery (?prefix) {
     format {
         <file://./context/discovery-ontology.template.html>
+        st:call-template(:versionNumber, ?prefix)
         st:call-template(:axioms, ?prefix)
     }
 } where {}
+
+template :versionNumber(?prefix) {
+    format { "%s" ?versionInfo }
+} where {
+    ?o a owl:Ontology ;
+       owl:versionInfo ?versionInfo .
+}
 
 template :axioms(?prefix) {
     "<section>"


### PR DESCRIPTION
As just noticed by @mmccool in the main call, this PR fixes a bug in the ontology where the current version of the document is not extracted from the `.ttl` file and therefore not up to date in the rendered version.