### PR TITLE
Alling Readme to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# Web of Things (WoT) Discovery
-[![Follow on Twitter](https://img.shields.io/twitter/follow/W3C_WoT.svg?label=follow+W3C_WoT)](https://twitter.com/W3C_WoT)
-[![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic)]( https://stackoverflow.com/questions/tagged/web-of-things)
+<p align="center">
+  <a href="https://w3.org/wot">
+    <img alt="Web of Things Homepage" src="https://www.w3.org/WoT/IG/wiki/images/8/8f/WOT-hz.svg" width="300" />
+  </a>
+</p>
 
-General information about the Web of Things can be found on https://www.w3.org/WoT/.
+<p align="center">
+  <a href="https://w3c.social/@wot">
+    <img alt="Follow on Mastodon" src="https://img.shields.io/mastodon/follow/111609289932468076?domain=https%3A%2F%2Fw3c.social"></a>
+  <a href="https://twitter.com/W3C_WoT">
+    <img alt="X (formerly Twitter) Follow" src="https://img.shields.io/twitter/follow/W3C_WoT"></a>
+  <a href="https://stackoverflow.com/questions/tagged/web-of-things">
+    <img alt="Stack Exchange questions" src="https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.w3.org/TR/wot-discovery/"> <!--  REC LINK -->
+    <img alt="Latest REC" src="https://img.shields.io/badge/W3C_REC-Latest-005a9c"></a>
+  <a href="https://w3c.github.io/wot-discovery/"> <!--  ED LINK -->
+    <img alt="Latest Editor's Draft" src="https://img.shields.io/badge/Editor's_Draft-Latest-fe914a"></a>
+</p>
+
+# Web of Things (WoT) Discovery
+
+General information about the Web of Things can be found at https://www.w3.org/WoT/.
   
 ---
 This is the repository for WoT Discovery discussion and specification development.
@@ -14,6 +34,22 @@ In this context, "discovery" is the automated process by which WoT Thing Descrip
 * [References](references.md): Normative and informative references.
 * [Proposals](proposals/README.md): Detailed feature proposals.
 * [Implementations](implementations/README.md): Links to implementations.
+
+## Logistics
+
+- Call information: We use the W3C Calendar. You can find the next CALL NAME call at https://www.w3.org/groups/wg/wot/calendar.
+- [Wiki](https://www.w3.org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) (contains agenda)
+- [Contribution rules](#contributing)
+
+## Publications
+
+- [Latest Editor's Draft](https://w3c.github.io/wot-discovery/) (syncs to this repository's main branch)
+- Recommendations:
+  - [Version 1.0](https://www.w3.org/TR/wot-scripting-api/) 
+- Other deliverables:
+  - [Implementation report](https://w3c.github.io/wot-discovery/testing/report.html)
+
+## Contributing
 
 To propose changes, create a PR following the procedures given in the [wot repo](https://github.com/w3c/wot).
 Also please create issues to note problems in the current content for which a solution is needed (ideally
@@ -35,6 +71,8 @@ which results in truncated labels, so make sure to embed fonts.
 For drawio a 
 [desktop installation](https://github.com/jgraph/drawio-desktop) is also available.
 
-The latest editor's draft is available [here](https://w3c.github.io/wot-discovery/).
+## Known Implementations
 
-The latest Implementation Report is available [here](https://w3c.github.io/wot-discovery/testing/report.html).
+The W3C WoT collects known implementations at <https://www.w3.org/WoT/developers/>. Implementations of Discovery are found under categories 
+"TD Directory (TDD) Implementations", "Runtime Implementations for TD Consumers" and "Runtime Implementations for TD Exposers". Further information
+can also be found in the [implementations](implementations/README.md) folder. 


### PR DESCRIPTION
As discussed in the marketing and main call I've been assigned to upgrade the readme of this repo with the guidelines defined in the [general template](https://github.com/w3c/wot/blob/main/README.template.md). This PR is a refactoring of the current README no information should be lost (please double check). Some warning points:
- The contributing section should probably be moved to a Contributing.md file
- There was not git tag to point for the REC version. 